### PR TITLE
feat: MAT-78 매치 기록 페이지 레이아웃 컴포넌트 추가

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as AboutImport } from './routes/about'
 import { Route as IndexImport } from './routes/index'
+import { Route as MatchesRecordRouteImport } from './routes/matches/record/route'
 
 // Create/Update Routes
 
@@ -25,6 +26,12 @@ const AboutRoute = AboutImport.update({
 const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const MatchesRecordRouteRoute = MatchesRecordRouteImport.update({
+  id: '/matches/record',
+  path: '/matches/record',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -46,6 +53,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutImport
       parentRoute: typeof rootRoute
     }
+    '/matches/record': {
+      id: '/matches/record'
+      path: '/matches/record'
+      fullPath: '/matches/record'
+      preLoaderRoute: typeof MatchesRecordRouteImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -54,36 +68,41 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/matches/record': typeof MatchesRecordRouteRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/matches/record': typeof MatchesRecordRouteRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/matches/record': typeof MatchesRecordRouteRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about'
+  fullPaths: '/' | '/about' | '/matches/record'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about'
-  id: '__root__' | '/' | '/about'
+  to: '/' | '/about' | '/matches/record'
+  id: '__root__' | '/' | '/about' | '/matches/record'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  MatchesRecordRouteRoute: typeof MatchesRecordRouteRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  MatchesRecordRouteRoute: MatchesRecordRouteRoute,
 }
 
 export const routeTree = rootRoute
@@ -97,7 +116,8 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/about"
+        "/about",
+        "/matches/record"
       ]
     },
     "/": {
@@ -105,6 +125,9 @@ export const routeTree = rootRoute
     },
     "/about": {
       "filePath": "about.tsx"
+    },
+    "/matches/record": {
+      "filePath": "matches/record/route.tsx"
     }
   }
 }

--- a/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.css.ts
+++ b/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.css.ts
@@ -1,7 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
-import { lightThemeVars } from '@/styles/theme.css';
-
 // NOTE: 현재 디자인은 고정 크기의 레이아웃으로 배치
 export const rootContainer = style({
   display: 'flex',
@@ -22,9 +20,6 @@ export const rootContainer = style({
 const flexColumn = style({
   display: 'flex',
   flexDirection: 'column',
-
-  // TODO: Sidebar 도입 시 bg 제거
-  backgroundColor: lightThemeVars.color.white.background,
 });
 
 export const teamContainer = style([
@@ -35,9 +30,10 @@ export const teamContainer = style([
   },
 ]);
 
-export const statsContainer = style([
+export const centerContainer = style([
   flexColumn,
   {
+    gap: 18,
     marginTop: 30,
     width: 280,
   },
@@ -46,6 +42,7 @@ export const statsContainer = style([
 export const infoContainer = style([
   flexColumn,
   {
+    gap: 16,
     marginTop: 30,
     width: 280,
   },

--- a/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.css.ts
+++ b/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.css.ts
@@ -1,0 +1,52 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+// NOTE: 현재 디자인은 고정 크기의 레이아웃으로 배치
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'row',
+  flexGrow: 1,
+  justifyContent: 'flex-start',
+  '@media': {
+    '(min-width: 1440px)': {
+      justifyContent: 'center',
+    },
+  },
+  gap: 16,
+  margin: '0 16px',
+  minWidth: 1380,
+  height: 964,
+});
+
+const flexColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+
+  // TODO: Sidebar 도입 시 bg 제거
+  backgroundColor: lightThemeVars.color.white.background,
+});
+
+export const teamContainer = style([
+  flexColumn,
+  {
+    marginTop: 12,
+    width: 354,
+  },
+]);
+
+export const statsContainer = style([
+  flexColumn,
+  {
+    marginTop: 30,
+    width: 280,
+  },
+]);
+
+export const infoContainer = style([
+  flexColumn,
+  {
+    marginTop: 30,
+    width: 280,
+  },
+]);

--- a/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.tsx
+++ b/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+
+import * as styles from './MatchRecordLayout.css';
+
+interface MatchRecordLayoutProps {
+  team1: ReactNode;
+  team2: ReactNode;
+  stats: ReactNode;
+  info: ReactNode;
+}
+
+export const MatchRecordLayout = ({
+  team1,
+  team2,
+  stats,
+  info,
+}: MatchRecordLayoutProps) => {
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.teamContainer}>{team1}</div>
+      <div className={styles.statsContainer}>{stats}</div>
+      <div className={styles.teamContainer}>{team2}</div>
+      <div className={styles.infoContainer}>{info}</div>
+    </div>
+  );
+};

--- a/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.tsx
+++ b/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.tsx
@@ -5,22 +5,38 @@ import * as styles from './MatchRecordLayout.css';
 interface MatchRecordLayoutProps {
   team1: ReactNode;
   team2: ReactNode;
-  stats: ReactNode;
+  teamStats: ReactNode;
+  selectedPlayer: ReactNode;
+  timer: ReactNode;
   info: ReactNode;
+  log: ReactNode;
+  memo: ReactNode;
 }
 
 export const MatchRecordLayout = ({
   team1,
   team2,
-  stats,
+  teamStats,
   info,
+  selectedPlayer,
+  timer,
+  log,
+  memo,
 }: MatchRecordLayoutProps) => {
   return (
     <div className={styles.rootContainer}>
       <div className={styles.teamContainer}>{team1}</div>
-      <div className={styles.statsContainer}>{stats}</div>
+      <div className={styles.centerContainer}>
+        {teamStats}
+        {selectedPlayer}
+      </div>
       <div className={styles.teamContainer}>{team2}</div>
-      <div className={styles.infoContainer}>{info}</div>
+      <div className={styles.infoContainer}>
+        {timer}
+        {info}
+        {log}
+        {memo}
+      </div>
     </div>
   );
 };

--- a/src/routes/matches/record/-components/MatchRecordLayout/index.tsx
+++ b/src/routes/matches/record/-components/MatchRecordLayout/index.tsx
@@ -1,0 +1,1 @@
+export * from './MatchRecordLayout';

--- a/src/routes/matches/record/-components/index.tsx
+++ b/src/routes/matches/record/-components/index.tsx
@@ -1,0 +1,1 @@
+export * from './MatchRecordLayout';

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -6,13 +6,26 @@ export const Route = createFileRoute('/matches/record')({
   component: MatchRecordPage,
 });
 
+// TO DO: 예시용 스타일로, 추후 제거 필요
+const s = (height: number | string) => ({
+  height,
+  backgroundColor: '#F2F3F7',
+  boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
+  borderRadius: 10,
+  borderBottom: '1px solid #E5E5EC',
+});
+
 function MatchRecordPage() {
   return (
     <MatchRecordLayout
-      team1={<div>Team 1</div>}
-      team2={<div>Team 2</div>}
-      stats={<div>Stats</div>}
-      info={<div>Info</div>}
+      team1={<div style={s('100%')}>Team 1</div>}
+      team2={<div style={s('100%')}>Team 2</div>}
+      teamStats={<div style={s(528)}>Stats</div>}
+      selectedPlayer={<div style={s(302)}>Selected Player</div>}
+      timer={<div style={s(116)}>Timer</div>}
+      info={<div style={s(200)}>Info</div>}
+      log={<div style={s(264)}>Log</div>}
+      memo={<div style={s(204)}>Memo</div>}
     />
   );
 }

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { MatchRecordLayout } from './-components';
+
+export const Route = createFileRoute('/matches/record')({
+  component: MatchRecordPage,
+});
+
+function MatchRecordPage() {
+  return (
+    <MatchRecordLayout
+      team1={<div>Team 1</div>}
+      team2={<div>Team 2</div>}
+      stats={<div>Stats</div>}
+      info={<div>Info</div>}
+    />
+  );
+}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,3 +1,0 @@
-export * from './theme.css';
-export * from './normalize.css';
-export * from './button.css';


### PR DESCRIPTION
## Description

- 매치 기록의 각 컴포넌트에 대한 레이아웃 추가

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/e6e985eb-3998-47f8-9073-8c61ad0896c9" />


## Changes

- [x] (번외 작업) `.css.ts` 파일을 barrel export 하면 오류가 발생해서 우선 제거했습니다!
- [x] 라우트 전용 컴포넌트이므로 routes 아래에 배치
- [x] 가로 폭 기준으로 1440px보다 작으면 좌측 정렬, 크면 중앙 정렬
- [x] 예시 영역을 배치, 실제 작업 시 교체 필요
- [x] 영역을 아래와 같이 구분

```
  team1,
  team2,
  teamStats,
  info,
  selectedPlayer,
  timer,
  log,
  memo,
```
