### PR TITLE
feat: MAT-94 교체선수 리스트 컴포넌트 퍼블리싱

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,7 +2,6 @@
 /** @jsxImportSource react */
 /* eslint-disable no-restricted-imports */
 import type { Preview } from '@storybook/react';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { initialize as initializeMSW, mswLoader } from 'msw-storybook-addon';
 
 import { ignoreDevResources } from '../src/mocks';
@@ -21,7 +20,6 @@ const preview: Preview = {
     Story => (
       <ReactQueryClientProvider>
         <Story />
-        <ReactQueryDevtools position='right' initialIsOpen={false} />
       </ReactQueryClientProvider>
     ),
   ],

--- a/src/components/SubstitutionPlayerList/EmptyList/EmptyList.css.ts
+++ b/src/components/SubstitutionPlayerList/EmptyList/EmptyList.css.ts
@@ -1,0 +1,18 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const container = style({
+  display: 'flex',
+  justifyContent: 'center',
+  height: '100%',
+});
+
+export const text = style({
+  marginTop: 51,
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray['500'],
+  fontSize: 14,
+  fontWeight: 500,
+});

--- a/src/components/SubstitutionPlayerList/EmptyList/EmptyList.tsx
+++ b/src/components/SubstitutionPlayerList/EmptyList/EmptyList.tsx
@@ -1,0 +1,9 @@
+import * as styles from './EmptyList.css';
+
+export const EmptyList = () => {
+  return (
+    <div className={styles.container}>
+      <span className={styles.text}>교체 선수가 없습니다.</span>
+    </div>
+  );
+};

--- a/src/components/SubstitutionPlayerList/EmptyList/index.ts
+++ b/src/components/SubstitutionPlayerList/EmptyList/index.ts
@@ -1,0 +1,1 @@
+export * from './EmptyList';

--- a/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.css.ts
+++ b/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.css.ts
@@ -1,0 +1,62 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const rootContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 14,
+  transition: 'background-color 0.3s ease',
+  padding: '6px 24px',
+
+  ':hover': {
+    backgroundColor: lightThemeVars.color.white.hover,
+  },
+});
+
+export const profileImage = style({
+  borderRadius: 100,
+  objectFit: 'cover',
+  width: 32,
+  height: 32,
+});
+
+export const textContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: 152,
+  height: 44,
+});
+
+export const textLeft = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+});
+
+const commonTextStyle = {
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  fontSize: 14,
+  color: lightThemeVars.color.black,
+  fontWeight: 500,
+};
+
+export const number = style([
+  commonTextStyle,
+  {
+    width: 17,
+    textAlign: 'center',
+  },
+]);
+
+export const name = style(commonTextStyle);
+
+export const position = style([
+  commonTextStyle,
+  {
+    color: lightThemeVars.color.gray['500'],
+    fontWeight: 400,
+  },
+]);

--- a/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.tsx
+++ b/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.tsx
@@ -1,0 +1,38 @@
+import { SyntheticEvent } from 'react';
+
+import noProfilePlayerImage from '@/assets/images/noProfilePlayer.png';
+import { Player } from '@/components/SubstitutionPlayerList';
+
+import * as styles from './PlayerListItem.css';
+
+export interface ListItemProps {
+  player: Player;
+}
+
+const setFallbackImageIfLoadFail = (
+  e: SyntheticEvent<HTMLImageElement, Event>,
+) => {
+  e.currentTarget.src = noProfilePlayerImage;
+};
+
+export const PlayerListItem = ({
+  player: { number, name, position },
+}: ListItemProps) => {
+  return (
+    <li className={styles.rootContainer}>
+      <img
+        className={styles.profileImage}
+        src={noProfilePlayerImage}
+        alt=''
+        onError={setFallbackImageIfLoadFail}
+      />
+      <div className={styles.textContainer}>
+        <div className={styles.textLeft}>
+          <span className={styles.number}>{number}</span>
+          <span className={styles.name}>{name}</span>
+        </div>
+        <span className={styles.position}>{position}</span>
+      </div>
+    </li>
+  );
+};

--- a/src/components/SubstitutionPlayerList/PlayerListItem/index.ts
+++ b/src/components/SubstitutionPlayerList/PlayerListItem/index.ts
@@ -1,0 +1,1 @@
+export * from './PlayerListItem';

--- a/src/components/SubstitutionPlayerList/SubstitutionPlayerList.css.ts
+++ b/src/components/SubstitutionPlayerList/SubstitutionPlayerList.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  border: `1px solid ${lightThemeVars.color.primary['100']}`,
+  borderRadius: 10,
+  height: 186,
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 10,
+  padding: '16px 24px',
+});
+
+export const title = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: '#000000',
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const list = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: 144,
+  overflowY: 'auto',
+});

--- a/src/components/SubstitutionPlayerList/SubstitutionPlayerList.stories.css.ts
+++ b/src/components/SubstitutionPlayerList/SubstitutionPlayerList.stories.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: 338,
+});

--- a/src/components/SubstitutionPlayerList/SubstitutionPlayerList.stories.tsx
+++ b/src/components/SubstitutionPlayerList/SubstitutionPlayerList.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SubstitutionPlayerList } from './SubstitutionPlayerList';
+import * as styles from './SubstitutionPlayerList.stories.css';
+
+const meta = {
+  title: 'Components/SubstitutionPlayerList',
+  component: SubstitutionPlayerList,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className={styles.container}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof SubstitutionPlayerList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    players: [
+      { number: '7', name: '손흥민', position: 'FW' },
+      { number: '10', name: '이강인', position: 'MF' },
+      { number: '4', name: '김민재', position: 'DF' },
+      { number: '1', name: '김승규', position: 'GK' },
+      { number: '11', name: '황희찬', position: 'FW' },
+      { number: '6', name: '황인범', position: 'MF' },
+      { number: '3', name: '김진수', position: 'DF' },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    players: [],
+  },
+};

--- a/src/components/SubstitutionPlayerList/SubstitutionPlayerList.tsx
+++ b/src/components/SubstitutionPlayerList/SubstitutionPlayerList.tsx
@@ -1,0 +1,38 @@
+import { EmptyList } from './EmptyList';
+import { PlayerListItem } from './PlayerListItem';
+import * as styles from './SubstitutionPlayerList.css';
+
+// FIXME: 우선 여기서 정의함
+export interface Player {
+  number: string;
+  name: string;
+  position: string;
+}
+
+export interface SubstitutionPlayerListProps {
+  players: Player[];
+}
+
+export const SubstitutionPlayerList = ({
+  players,
+}: SubstitutionPlayerListProps) => {
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.header}>
+        <span className={styles.title}>교체 선수</span>
+      </div>
+      <ul className={styles.list}>
+        {players.length === 0 ? (
+          <EmptyList />
+        ) : (
+          players.map(player => (
+            <PlayerListItem
+              key={`${player.number}-${player.name}`}
+              player={player}
+            />
+          ))
+        )}
+      </ul>
+    </div>
+  );
+};

--- a/src/components/SubstitutionPlayerList/index.ts
+++ b/src/components/SubstitutionPlayerList/index.ts
@@ -1,0 +1,1 @@
+export * from './SubstitutionPlayerList';

--- a/src/styles/reset.css.ts
+++ b/src/styles/reset.css.ts
@@ -4,3 +4,7 @@ globalStyle('ul', {
   margin: 0,
   padding: 0,
 });
+
+globalStyle('button', {
+  backgroundColor: 'transparent',
+});


### PR DESCRIPTION
## Description

- [Jira: MAT-94](https://match-day.atlassian.net/browse/MAT-94)
- 교체선수 리스트 컴포넌트 퍼블리싱

## Changes

- [x] 정상 상태, 빈 상태 퍼블리싱
- [x] 버튼의 기본 배경색 제거
- [x] 스토리 추가

### Screenshots

- (스토리북 참고)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 교체 선수 목록을 보여주는 SubstitutionPlayerList 컴포넌트가 추가되었습니다. 교체 선수가 없을 경우 안내 메시지가 표시됩니다.
  - 각 교체 선수 항목(PlayerListItem)에 선수 번호, 이름, 포지션 및 프로필 이미지가 표시됩니다.

- **스타일**
  - SubstitutionPlayerList 및 하위 컴포넌트에 대한 스타일이 적용되어 일관된 레이아웃과 테마를 제공합니다.
  - 버튼의 배경색이 투명하게 초기화되어 전체적인 스타일이 개선되었습니다.

- **문서화**
  - SubstitutionPlayerList 컴포넌트의 스토리북 예제가 추가되어 다양한 상태를 미리 볼 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->