### PR TITLE
feat: MAT-95 팀 스텟 증감 영역 퍼블리싱

### DIFF
--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,0 +1,2 @@
+export { default as PlusIcon } from './plus.svg?react';
+export { default as MinusIcon } from './minus.svg?react';

--- a/src/assets/icons/minus.svg
+++ b/src/assets/icons/minus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 2" fill="none">
+  <path d="M1.43359 1H13.5668" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/assets/icons/plus.svg
+++ b/src/assets/icons/plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 14" fill="none">
+  <path d="M1.43262 6.99951H13.5661" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M7.5 0.933105L7.5 13.0666" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.css.ts
+++ b/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.css.ts
@@ -47,10 +47,15 @@ export const button = style({
   cursor: 'pointer',
   width: 24,
   height: 24,
-
-  color: lightThemeVars.color.gray['500'],
+  color: lightThemeVars.color.gray['600'],
 
   ':hover': {
     backgroundColor: lightThemeVars.color.primary['300'],
+  },
+
+  // FIXME: Base Button에 들어갈 스타일로 보임.
+  ':disabled': {
+    backgroundColor: 'transparent',
+    cursor: 'not-allowed',
   },
 });

--- a/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.css.ts
+++ b/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.css.ts
@@ -1,0 +1,56 @@
+import { style } from '@vanilla-extract/css';
+
+import { teamColor } from '@/components/PlayerList/TeamColor.css';
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 10,
+  border: `1px solid ${lightThemeVars.color.primary['100']}`,
+  borderRadius: 6,
+  padding: 9,
+});
+
+export const title = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray['500'],
+  fontSize: 14,
+  fontWeight: 400,
+});
+
+export const value = style({
+  width: 35,
+  textAlign: 'center',
+  lineHeight: '1',
+  letterSpacing: -0.35,
+  color: teamColor,
+  fontSize: 32,
+  fontWeight: 500,
+});
+
+export const groupContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+});
+
+export const button = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'background-color 0.3s ease',
+  border: `1px solid ${lightThemeVars.color.primary['300']}`,
+  borderRadius: '50%',
+  cursor: 'pointer',
+  width: 24,
+  height: 24,
+
+  color: lightThemeVars.color.gray['500'],
+
+  ':hover': {
+    backgroundColor: lightThemeVars.color.primary['300'],
+  },
+});

--- a/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.tsx
+++ b/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.tsx
@@ -1,0 +1,39 @@
+import * as styles from './StatCounterItem.css';
+
+export interface StatCounterItemProps {
+  title: string;
+  value: number;
+  onIncrement?: () => void;
+  onDecrement?: () => void;
+}
+
+export const StatCounterItem = ({
+  title,
+  value,
+  onIncrement,
+  onDecrement,
+}: StatCounterItemProps) => {
+  return (
+    <div className={styles.rootContainer}>
+      <span className={styles.title}>{title}</span>
+      <div className={styles.groupContainer}>
+        {/* FIXME: 추후 Text가 아닌 Icon 사용 예정 */}
+        <button
+          className={styles.button}
+          onClick={onDecrement}
+          aria-label='감소'
+        >
+          -
+        </button>
+        <span className={styles.value}>{value}</span>
+        <button
+          className={styles.button}
+          onClick={onIncrement}
+          aria-label='증가'
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.tsx
+++ b/src/components/TeamStatCounterGrid/StatCounterItem/StatCounterItem.tsx
@@ -1,3 +1,5 @@
+import { MinusIcon, PlusIcon } from '@/assets/icons';
+
 import * as styles from './StatCounterItem.css';
 
 export interface StatCounterItemProps {
@@ -22,8 +24,9 @@ export const StatCounterItem = ({
           className={styles.button}
           onClick={onDecrement}
           aria-label='감소'
+          disabled={value === 0}
         >
-          -
+          <MinusIcon />
         </button>
         <span className={styles.value}>{value}</span>
         <button
@@ -31,7 +34,7 @@ export const StatCounterItem = ({
           onClick={onIncrement}
           aria-label='증가'
         >
-          +
+          <PlusIcon />
         </button>
       </div>
     </div>

--- a/src/components/TeamStatCounterGrid/StatCounterItem/index.ts
+++ b/src/components/TeamStatCounterGrid/StatCounterItem/index.ts
@@ -1,0 +1,1 @@
+export * from './StatCounterItem';

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.css.ts
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css';
+
+export const rootContainer = style({
+  display: 'grid',
+  gridTemplateRows: 'repeat(2, 80px)',
+  gridTemplateColumns: 'repeat(3, 110px)',
+  gap: 4,
+});

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.stories.tsx
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+// FIXME: teamColor 공통화 필요
+import { teamColor } from '@/components/PlayerList/TeamColor.css';
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { TeamStatCounterGrid } from './TeamStatCounterGrid';
+
+const meta = {
+  title: 'Components/TeamStatCounterGrid',
+  component: TeamStatCounterGrid,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={assignInlineVars({
+          [teamColor]: lightThemeVars.color.soccer.red,
+        })}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof TeamStatCounterGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const statFields = [
+  '슈팅',
+  '유효 슈팅',
+  '코너킥',
+  '오프사이드',
+  '파울',
+  '경고',
+];
+
+export const Default: Story = {
+  args: {
+    stats: statFields.map(title => ({
+      title,
+      value: Math.floor(Math.random() * 30),
+    })),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    stats: statFields.map(title => ({ title, value: 0 })),
+  },
+};

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.tsx
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.tsx
@@ -1,0 +1,43 @@
+import { StatCounterItem } from './StatCounterItem';
+import * as styles from './TeamStatCounterGrid.css';
+
+interface TeamStat {
+  title: string;
+  value: number;
+}
+
+export interface TeamStatCounterGridProps {
+  stats: TeamStat[];
+  onStatChange?: (index: number, newValue: number) => void;
+}
+
+export const TeamStatCounterGrid = ({
+  stats,
+  onStatChange,
+}: TeamStatCounterGridProps) => {
+  const handleIncrement = (index: number) => {
+    if (onStatChange) {
+      onStatChange(index, stats[index].value + 1);
+    }
+  };
+
+  const handleDecrement = (index: number) => {
+    if (onStatChange && stats[index].value > 0) {
+      onStatChange(index, stats[index].value - 1);
+    }
+  };
+
+  return (
+    <div className={styles.rootContainer}>
+      {stats.map((stat, index) => (
+        <StatCounterItem
+          key={index}
+          title={stat.title}
+          value={stat.value}
+          onIncrement={() => handleIncrement(index)}
+          onDecrement={() => handleDecrement(index)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.tsx
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.tsx
@@ -31,7 +31,7 @@ export const TeamStatCounterGrid = ({
     <div className={styles.rootContainer}>
       {stats.map((stat, index) => (
         <StatCounterItem
-          key={index}
+          key={`${stat.title}-${index}`}
           title={stat.title}
           value={stat.value}
           onIncrement={() => handleIncrement(index)}

--- a/src/components/TeamStatCounterGrid/index.ts
+++ b/src/components/TeamStatCounterGrid/index.ts
@@ -1,0 +1,1 @@
+export * from './TeamStatCounterGrid';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-svgr/client" />


### PR DESCRIPTION
## Description

- [Jira: MAT-95](https://match-day.atlassian.net/browse/MAT-95)
- 팀 스텟 증감 영역 퍼블리싱

## Changes

- [x] Vite Svgr 설정 누락된 부분 추가 (`vite-env.d.ts`)
- [x] +, - 아이콘 추가
- [x] 컴포넌트 퍼블리싱
- [x] 스토리 추가

### Screenshots

- (스토리북 참고)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 팀 통계 수치를 표시하고 조정할 수 있는 새로운 그리드형 통계 카운터 컴포넌트가 추가되었습니다.
    - 각 통계 항목별로 증가/감소 버튼이 제공되어 값을 쉽게 변경할 수 있습니다.
    - Storybook에서 기본값 및 빈 값 상태를 확인할 수 있는 스토리가 추가되었습니다.
    - SVG 아이콘(플러스, 마이너스)을 React 컴포넌트로 사용할 수 있게 되었습니다.

- **Style**
    - 통계 카운터 및 그리드 레이아웃에 대한 새로운 스타일이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->