### PR TITLE
feat: MAT-104 경기 정보 컴포넌트 퍼블리싱

### DIFF
--- a/src/components/MatchSchedule/MatchSchedule.css.ts
+++ b/src/components/MatchSchedule/MatchSchedule.css.ts
@@ -1,0 +1,43 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  borderRadius: 10,
+  boxShadow: '4px 4px 8px rgba(0, 0, 0, 0.05)',
+  background: lightThemeVars.color.white.main,
+  padding: '24px 20px',
+});
+
+export const infoItem = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const labelContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  width: 71,
+});
+
+export const label = style({
+  borderRadius: 4,
+  background: lightThemeVars.color.primary[300],
+  padding: '5px 10px',
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.primary[800],
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const value = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+});

--- a/src/components/MatchSchedule/MatchSchedule.stories.tsx
+++ b/src/components/MatchSchedule/MatchSchedule.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { MatchSchedule } from './MatchSchedule';
+
+const meta = {
+  title: 'Components/MatchSchedule',
+  component: MatchSchedule,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: 300,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof MatchSchedule>;
+
+export default meta;
+type Story = StoryObj<typeof MatchSchedule>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      { label: '장소', value: '한양대학교 대운동장' },
+      { label: '날짜', value: '2025-04-16 (수)' },
+      { label: '시간', value: '09 : 30 ~ 11 : 30' },
+      { label: '주심', value: '김태인' },
+      { label: '부심1', value: '김주용' },
+      { label: '부심2', value: '주유나' },
+      { label: '대기심', value: '김성빈' },
+    ],
+  },
+};

--- a/src/components/MatchSchedule/MatchSchedule.tsx
+++ b/src/components/MatchSchedule/MatchSchedule.tsx
@@ -1,0 +1,25 @@
+import * as styles from './MatchSchedule.css';
+
+interface MatchScheduleItem {
+  label: string;
+  value: string;
+}
+
+interface MatchScheduleProps {
+  items: MatchScheduleItem[];
+}
+
+export const MatchSchedule = ({ items }: MatchScheduleProps) => {
+  return (
+    <div className={styles.container}>
+      {items.map(({ label, value: itemValue }) => (
+        <div key={label} className={styles.infoItem}>
+          <div className={styles.labelContainer}>
+            <div className={styles.label}>{label}</div>
+          </div>
+          <div className={styles.value}>{itemValue}</div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/MatchSchedule/index.ts
+++ b/src/components/MatchSchedule/index.ts
@@ -1,0 +1,1 @@
+export * from './MatchSchedule';

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -35,6 +35,6 @@ const lightTheme = {
     },
     warning: '#D91920',
   },
-};
+} as const;
 
 export const lightThemeVars = createGlobalTheme(':root', lightTheme);


### PR DESCRIPTION
## Description

- [Jira: MAT-104](https://match-day.atlassian.net/browse/MAT-104)
- 경기 정보 컴포넌트 퍼블리싱

## Changes

- [x] `theme.css.ts`의 설정 값이 IDE 상에서 보이도록 `as const` 추가
- [x] 경기 정보 컴포넌트 퍼블리싱
- [x] 경기 정보 컴포넌트 Storybook 문서화

### Screenshots

- [스토리북 참고]()

