### PR TITLE
feat: MAT-117 경기 팀 스텟 비교 영역 컴포넌트 퍼블리싱

### DIFF
--- a/.cursor/rules/vanilla-extract.mdc
+++ b/.cursor/rules/vanilla-extract.mdc
@@ -1,0 +1,17 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+
+스타일은 항상 Vanilla Extract로 한다.
+
+Vanilla Extract 작성 시 값이 단일 숫자인 경우 string 대신 number를 사용한다.
+
+Vanilla Extract에서 색상 값 사용 시 src/styles/theme.css.ts 파일의 vars를 참고해 동일 색상이 있다면 해당 색상을 사용한다.
+
+Vanilla Extract에서 Font-family는 항상 Pretendard Variable 이므로 생략 가능하다.
+
+스타일 import 시에는 항상 `import * as styles`로 import 한다.
+
+스타일 파일명은 항상 `컴포넌트이름.css.ts`로 한다.

--- a/src/components/StatCompareCounter/StatCompareCounter.css.ts
+++ b/src/components/StatCompareCounter/StatCompareCounter.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { lightThemeVars } from '@/styles/theme.css';
@@ -14,7 +14,6 @@ export const labelContainer = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  width: '100%',
 });
 
 export const value = recipe({
@@ -47,36 +46,4 @@ export const label = style({
 export const barContainer = style({
   display: 'flex',
   gap: 4,
-  width: '100%',
-});
-
-export const barBackground = recipe({
-  base: {
-    flex: 1,
-    borderRadius: 10,
-    backgroundColor: lightThemeVars.color.gray[100],
-  },
-  variants: {
-    left: {
-      true: {
-        transform: 'rotate(180deg)',
-      },
-    },
-  },
-  defaultVariants: {
-    left: false,
-  },
-});
-
-// NOTE: width를 사용하면 동적으로 width 값을 CSS Variable로 주입해야 함.
-const barAnimation = keyframes({
-  '0%': { transform: 'scaleX(0)', transformOrigin: 'left' },
-  '100%': { transform: 'scaleX(1)', transformOrigin: 'left' },
-});
-
-export const barBase = style({
-  transition: 'width 0.3s ease-in-out',
-  borderRadius: 10,
-  height: 6,
-  animation: `${barAnimation} 0.8s ease forwards`,
 });

--- a/src/components/StatCompareCounter/StatCompareCounter.css.ts
+++ b/src/components/StatCompareCounter/StatCompareCounter.css.ts
@@ -1,0 +1,82 @@
+import { keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  width: '100%',
+});
+
+export const labelContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+export const value = recipe({
+  base: {
+    width: 14,
+    lineHeight: 1.4,
+    letterSpacing: -0.35,
+    color: lightThemeVars.color.black,
+    fontSize: 14,
+    fontWeight: 500,
+  },
+  variants: {
+    align: {
+      right: {
+        textAlign: 'right',
+      },
+    },
+  },
+  defaultVariants: {},
+});
+
+export const label = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const barContainer = style({
+  display: 'flex',
+  gap: 4,
+  width: '100%',
+});
+
+export const barBackground = recipe({
+  base: {
+    flex: 1,
+    borderRadius: 10,
+    backgroundColor: lightThemeVars.color.gray[100],
+  },
+  variants: {
+    left: {
+      true: {
+        transform: 'rotate(180deg)',
+      },
+    },
+  },
+  defaultVariants: {
+    left: false,
+  },
+});
+
+// NOTE: width를 사용하면 동적으로 width 값을 CSS Variable로 주입해야 함.
+const barAnimation = keyframes({
+  '0%': { transform: 'scaleX(0)', transformOrigin: 'left' },
+  '100%': { transform: 'scaleX(1)', transformOrigin: 'left' },
+});
+
+export const barBase = style({
+  transition: 'width 0.3s ease-in-out',
+  borderRadius: 10,
+  height: 6,
+  animation: `${barAnimation} 0.8s ease forwards`,
+});

--- a/src/components/StatCompareCounter/StatCompareCounter.stories.tsx
+++ b/src/components/StatCompareCounter/StatCompareCounter.stories.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+import {
+  teamAwayColor,
+  teamHomeColor,
+} from '@/components/MatchLogList/colors.css';
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { StatCompareCounter } from './StatCompareCounter';
+
+const meta = {
+  title: 'Components/StatCompareCounter',
+  component: StatCompareCounter,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: 280,
+          ...assignInlineVars({
+            [teamHomeColor]: lightThemeVars.color.soccer.red,
+            [teamAwayColor]: '#003A70',
+          }),
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof StatCompareCounter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: '코너킥',
+    leftValue: 7,
+    rightValue: 10,
+    maxValue: 20,
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    label: '슛',
+    leftValue: 5,
+    rightValue: 8,
+    maxValue: 20,
+  },
+};
+
+export const MaxValueExample: Story = {
+  args: {
+    label: '슈팅',
+    leftValue: 15,
+    rightValue: 20,
+    maxValue: 20,
+  },
+};
+
+type InteractiveValues = {
+  leftValue: number;
+  rightValue: number;
+};
+
+export const Stateful = () => {
+  const MAX_VALUE = 30;
+  const [values, setValues] = useState<InteractiveValues>({
+    leftValue: 0,
+    rightValue: 9,
+  });
+
+  const handleIncrease = (side: keyof InteractiveValues) => {
+    setValues(prev => ({
+      ...prev,
+      [side]: Math.min(prev[side] + 1, MAX_VALUE),
+    }));
+  };
+
+  const styles = {
+    button: {
+      marginTop: 20,
+      display: 'flex',
+      gap: 8,
+    },
+    container: {
+      padding: 20,
+      width: '100%',
+    },
+    info: {
+      marginBottom: 10,
+      fontSize: 14,
+    },
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.info}>
+        최대값: {MAX_VALUE} (값 범위: 0~{MAX_VALUE})
+      </div>
+
+      <StatCompareCounter
+        label='코너킥'
+        leftValue={values.leftValue}
+        rightValue={values.rightValue}
+        maxValue={MAX_VALUE}
+      />
+
+      <div style={styles.button}>
+        <button onClick={() => handleIncrease('leftValue')}>
+          왼쪽 값 증가
+        </button>
+        <button onClick={() => handleIncrease('rightValue')}>
+          오른쪽 값 증가
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/StatCompareCounter/StatCompareCounter.tsx
+++ b/src/components/StatCompareCounter/StatCompareCounter.tsx
@@ -1,0 +1,45 @@
+import { TinyBarChart } from '@/components';
+import {
+  teamAwayColor,
+  teamHomeColor,
+} from '@/components/MatchLogList/colors.css';
+
+import * as styles from './StatCompareCounter.css';
+
+type StatCompareCounterProps = {
+  label: string;
+  leftValue: number;
+  rightValue: number;
+  maxValue: number;
+};
+
+export const StatCompareCounter = ({
+  label,
+  leftValue,
+  rightValue,
+  maxValue,
+}: StatCompareCounterProps) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.labelContainer}>
+        <div className={styles.value()}>{leftValue}</div>
+        <div className={styles.label}>{label}</div>
+        <div className={styles.value({ align: 'right' })}>{rightValue}</div>
+      </div>
+      <div className={styles.barContainer}>
+        <TinyBarChart
+          isLeft={true}
+          color={teamHomeColor}
+          value={leftValue}
+          maxValue={maxValue}
+        />
+        <TinyBarChart
+          isLeft={false}
+          color={teamAwayColor}
+          value={rightValue}
+          maxValue={maxValue}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/StatCompareCounter/index.ts
+++ b/src/components/StatCompareCounter/index.ts
@@ -1,0 +1,1 @@
+export * from './StatCompareCounter';

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.css.ts
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.css.ts
@@ -1,0 +1,11 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+  paddingTop: 22,
+  paddingRight: 20,
+  paddingBottom: 22,
+  paddingLeft: 20,
+});

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.css.ts
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.css.ts
@@ -4,8 +4,5 @@ export const container = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 24,
-  paddingTop: 22,
-  paddingRight: 20,
-  paddingBottom: 22,
-  paddingLeft: 20,
+  padding: [22, 20],
 });

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.stories.tsx
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+import {
+  teamAwayColor,
+  teamHomeColor,
+} from '@/components/MatchLogList/colors.css';
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { TeamStatCompareCounterList } from './TeamStatCompareCounterList';
+
+const meta = {
+  title: 'Components/TeamStatCompareCounterList',
+  component: TeamStatCompareCounterList,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: 320,
+          ...assignInlineVars({
+            [teamHomeColor]: lightThemeVars.color.soccer.red,
+            [teamAwayColor]: '#003A70',
+          }),
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof TeamStatCompareCounterList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    maxValue: 30,
+    homeTeamStat: {
+      슈팅: 12,
+      '유효 슈팅': 8,
+      '코너 킥': 5,
+      '오프 사이드': 2,
+      파울: 10,
+      경고: 3,
+    },
+    awayTeamStat: {
+      슈팅: 8,
+      '유효 슈팅': 4,
+      '코너 킥': 7,
+      '오프 사이드': 3,
+      파울: 14,
+      경고: 2,
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    maxValue: 30,
+    homeTeamStat: {
+      슈팅: 0,
+      '유효 슈팅': 0,
+      '코너 킥': 0,
+      '오프 사이드': 0,
+      파울: 0,
+      경고: 0,
+    },
+    awayTeamStat: {
+      슈팅: 0,
+      '유효 슈팅': 0,
+      '코너 킥': 0,
+      '오프 사이드': 0,
+      파울: 0,
+      경고: 0,
+    },
+  },
+};
+
+export const Max20: Story = {
+  args: {
+    maxValue: 20,
+    homeTeamStat: {
+      슈팅: 10,
+      '유효 슈팅': 5,
+      '코너 킥': 5,
+      '오프 사이드': 2,
+      파울: 12,
+      경고: 2,
+    },
+    awayTeamStat: {
+      슈팅: 10,
+      '유효 슈팅': 5,
+      '코너 킥': 5,
+      '오프 사이드': 2,
+      파울: 12,
+      경고: 2,
+    },
+  },
+};

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.tsx
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.tsx
@@ -1,0 +1,40 @@
+import { StatCompareCounter } from '@/components';
+
+import * as styles from './TeamStatCompareCounterList.css';
+
+type Stat = '슈팅' | '유효 슈팅' | '코너 킥' | '오프 사이드' | '파울' | '경고';
+
+const STAT_LIST: Stat[] = [
+  '슈팅',
+  '유효 슈팅',
+  '코너 킥',
+  '오프 사이드',
+  '파울',
+  '경고',
+];
+
+type TeamStatCompareCounterListProps = {
+  maxValue: number;
+  homeTeamStat: Record<Stat, number>;
+  awayTeamStat: Record<Stat, number>;
+};
+
+export const TeamStatCompareCounterList = ({
+  maxValue,
+  homeTeamStat,
+  awayTeamStat,
+}: TeamStatCompareCounterListProps) => {
+  return (
+    <div className={styles.container}>
+      {STAT_LIST.map(stat => (
+        <StatCompareCounter
+          key={stat}
+          label={stat}
+          leftValue={homeTeamStat[stat]}
+          rightValue={awayTeamStat[stat]}
+          maxValue={maxValue}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/TeamStatCompareCounterList/index.ts
+++ b/src/components/TeamStatCompareCounterList/index.ts
@@ -1,0 +1,1 @@
+export * from './TeamStatCompareCounterList';

--- a/src/components/TinyBarChart/TinyBarChart.css.ts
+++ b/src/components/TinyBarChart/TinyBarChart.css.ts
@@ -1,0 +1,35 @@
+import { keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const container = recipe({
+  base: {
+    flex: 1,
+    borderRadius: 10,
+    backgroundColor: lightThemeVars.color.gray[100],
+  },
+  variants: {
+    left: {
+      true: {
+        transform: 'rotate(180deg)',
+      },
+    },
+  },
+  defaultVariants: {
+    left: false,
+  },
+});
+
+// NOTE: width를 사용하면 동적으로 width 값을 CSS Variable로 주입해야 함.
+const barAnimation = keyframes({
+  '0%': { transform: 'scaleX(0)', transformOrigin: 'left' },
+  '100%': { transform: 'scaleX(1)', transformOrigin: 'left' },
+});
+
+export const bar = style({
+  transition: 'width 0.3s ease-in-out',
+  borderRadius: 10,
+  height: 6,
+  animation: `${barAnimation} 0.8s ease forwards`,
+});

--- a/src/components/TinyBarChart/TinyBarChart.css.ts
+++ b/src/components/TinyBarChart/TinyBarChart.css.ts
@@ -6,7 +6,7 @@ import { lightThemeVars } from '@/styles/theme.css';
 export const container = recipe({
   base: {
     flex: 1,
-    borderRadius: 10,
+    borderRadius: 3,
     backgroundColor: lightThemeVars.color.gray[100],
   },
   variants: {
@@ -29,7 +29,7 @@ const barAnimation = keyframes({
 
 export const bar = style({
   transition: 'width 0.3s ease-in-out',
-  borderRadius: 10,
+  borderRadius: 3,
   height: 6,
   animation: `${barAnimation} 0.8s ease forwards`,
 });

--- a/src/components/TinyBarChart/TinyBarChart.stories.tsx
+++ b/src/components/TinyBarChart/TinyBarChart.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { TinyBarChart } from './TinyBarChart';
+
+const meta = {
+  title: 'Components/TinyBarChart',
+  component: TinyBarChart,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: 280, padding: 20 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof TinyBarChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: 70,
+    maxValue: 100,
+    isLeft: false,
+    color: '#FF9500',
+  },
+};
+
+export const Zero: Story = {
+  args: {
+    value: 0,
+    maxValue: 100,
+    isLeft: false,
+    color: '#FF9500',
+  },
+};
+
+export const MaxValue: Story = {
+  args: {
+    value: 100,
+    maxValue: 100,
+    isLeft: false,
+    color: '#FF9500',
+  },
+};
+
+export const LeftSide: Story = {
+  args: {
+    value: 70,
+    maxValue: 100,
+    isLeft: true,
+    color: '#003A70',
+  },
+};

--- a/src/components/TinyBarChart/TinyBarChart.tsx
+++ b/src/components/TinyBarChart/TinyBarChart.tsx
@@ -1,0 +1,34 @@
+import * as styles from './TinyBarChart.css';
+
+type TinyBarChartProps = {
+  value: number;
+  maxValue: number;
+  isLeft: boolean;
+  color: string;
+};
+
+/**
+ * 좌측, 우측으로 간단한 BarChart 기능
+ * 간단한 애니메이션을 탑재
+ */
+export const TinyBarChart = ({
+  value,
+  maxValue,
+  isLeft,
+  color,
+}: TinyBarChartProps) => {
+  const boundedValue = Math.min(value, maxValue);
+  const width = (boundedValue / maxValue) * 100;
+
+  return (
+    <div className={styles.container({ left: isLeft })}>
+      <div
+        className={styles.bar}
+        style={{
+          width: `${width}%`,
+          backgroundColor: color,
+        }}
+      />
+    </div>
+  );
+};

--- a/src/components/TinyBarChart/index.ts
+++ b/src/components/TinyBarChart/index.ts
@@ -1,0 +1,1 @@
+export * from './TinyBarChart';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,6 @@ export * from './PlayerStatCounterGrid';
 export * from './MatchRecordSimpleMemo';
 export * from './MatchTimeController';
 export * from './GameScoreArea';
+export * from './TinyBarChart';
+export * from './StatCompareCounter';
+export * from './TeamStatCompareCounterList';


### PR DESCRIPTION
## Description

- [Jira: MAT-117](https://match-day.atlassian.net/browse/MAT-117)
- 경기 팀 스텟 비교 영역 컴포넌트 퍼블리싱

## Changes

- [x] 차트 단위 Bar 컴포넌트 - `TinyBarChart` 퍼블리싱, 문서화
- [x] 단위 스텟 비교 컴포넌트 - `StatCompareCounter` 퍼블리싱, 문서화
- [x] 전체 스텟 비교 컴포넌트 - `TeamStatCompareCounterList` 퍼블리싱, 문서화

### Screenshots

- [스토리북 참고](https://680b08a7575f04471f05ad14-ktglirasao.chromatic.com/)
