### PR TITLE
feat: MAT-122 경기 기록 페이지 레이아웃 퍼블리싱 1차

### DIFF
--- a/src/components/MatchLogList/MatchLogList.css.ts
+++ b/src/components/MatchLogList/MatchLogList.css.ts
@@ -1,16 +1,19 @@
 import { style } from '@vanilla-extract/css';
 
+import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
-export const rootContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  border: `1px solid ${lightThemeVars.color.primary[100]}`, // NOTE: 고정 폭 사용
-  borderRadius: 10,
-  paddingBottom: 4,
-  height: 228,
-  overflow: 'hidden',
-});
+export const rootContainer = style([
+  commonPaper,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    border: `1px solid ${lightThemeVars.color.primary[100]}`, // NOTE: 고정 폭 사용
+    paddingBottom: 4,
+    height: 228,
+    overflow: 'hidden',
+  },
+]);
 
 export const header = style({
   display: 'flex',

--- a/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.css.ts
+++ b/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.css.ts
@@ -7,6 +7,7 @@ export const container = style({
   borderRadius: 10,
   boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
   background: lightThemeVars.color.white.background,
+  height: 204,
 });
 
 export const header = style({
@@ -28,7 +29,7 @@ export const textarea = style({
   background: lightThemeVars.color.white.background,
   padding: '8px 12px',
   width: '100%',
-  height: 144,
+  height: 'calc(100% - 32px)', // NOTE: calc를 사용하지 않는 방법 = ?
   resize: 'none',
   lineHeight: 1.5,
   ':focus': {

--- a/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.css.ts
+++ b/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.css.ts
@@ -1,14 +1,15 @@
 import { style } from '@vanilla-extract/css';
 
+import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
-export const container = style({
-  border: '4px solid #FFFFFF',
-  borderRadius: 10,
-  boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
-  background: lightThemeVars.color.white.background,
-  height: 204,
-});
+export const container = style([
+  commonPaper,
+  {
+    border: '4px solid #FFFFFF',
+    height: 204,
+  },
+]);
 
 export const header = style({
   background: '#FFFFFF',

--- a/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.stories.tsx
+++ b/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 
 import { lightThemeVars } from '@/styles/theme.css';
 
-import MatchRecordSimpleMemo from './MatchRecordSimpleMemo';
+import { MatchRecordSimpleMemo } from './MatchRecordSimpleMemo';
 
 const meta = {
   title: 'Components/MatchRecordSimpleMemo',

--- a/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.tsx
+++ b/src/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 import * as styles from './MatchRecordSimpleMemo.css';
 
 interface Props {
@@ -8,7 +6,11 @@ interface Props {
   placeholder?: string;
 }
 
-const MatchRecordSimpleMemo = ({ value, onChange, placeholder }: Props) => {
+export const MatchRecordSimpleMemo = ({
+  value,
+  onChange,
+  placeholder,
+}: Props) => {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -23,5 +25,3 @@ const MatchRecordSimpleMemo = ({ value, onChange, placeholder }: Props) => {
     </div>
   );
 };
-
-export default memo(MatchRecordSimpleMemo);

--- a/src/components/MatchSchedule/MatchSchedule.css.ts
+++ b/src/components/MatchSchedule/MatchSchedule.css.ts
@@ -24,9 +24,12 @@ export const labelContainer = style({
 });
 
 export const label = style({
-  borderRadius: 4,
+  borderRadius: 6,
   background: lightThemeVars.color.primary[300],
-  padding: '5px 10px',
+  padding: '0 10px',
+  height: 20,
+  verticalAlign: 'middle',
+  textAlign: 'center',
   lineHeight: 1.4,
   letterSpacing: -0.35,
   color: lightThemeVars.color.primary[800],

--- a/src/components/MatchTimeController/MatchTimeController.css.ts
+++ b/src/components/MatchTimeController/MatchTimeController.css.ts
@@ -1,20 +1,21 @@
 import { style } from '@vanilla-extract/css';
 
+import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
-export const container = style({
-  boxSizing: 'border-box',
-  display: 'flex',
-  alignItems: 'center',
-  gap: 34,
-  borderRadius: 10,
-  boxShadow: '4px 4px 8px rgba(0, 0, 0, 0.05)',
-  background: lightThemeVars.color.white.main,
-  padding: '0 0 0 20px',
-  width: '100%',
-  height: 116,
-  overflow: 'hidden',
-});
+export const container = style([
+  commonPaper,
+  {
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 34,
+    padding: '0 0 0 20px',
+    width: '100%',
+    height: 116,
+    overflow: 'hidden',
+  },
+]);
 
 export const timeSection = style({
   display: 'flex',

--- a/src/components/MatchTimeController/MatchTimeController.css.ts
+++ b/src/components/MatchTimeController/MatchTimeController.css.ts
@@ -3,6 +3,7 @@ import { style } from '@vanilla-extract/css';
 import { lightThemeVars } from '@/styles/theme.css';
 
 export const container = style({
+  boxSizing: 'border-box',
   display: 'flex',
   alignItems: 'center',
   gap: 34,

--- a/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.css.ts
+++ b/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.css.ts
@@ -1,14 +1,17 @@
 import { style } from '@vanilla-extract/css';
 
 import { teamColor } from '@/components/PlayerList/TeamColor.css';
+import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
-export const rootContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  border: `2px solid ${teamColor}`,
-  borderRadius: 10,
-});
+export const rootContainer = style([
+  commonPaper,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    border: `2px solid ${teamColor}`,
+  },
+]);
 
 export const mainContainer = style({
   display: 'flex',

--- a/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
 import { StartingPlayer, Team } from '@/apis';
+import { teamColor } from '@/components/PlayerList/TeamColor.css';
 import { StatCounterItem } from '@/components/StatCounterItem';
 
 import { CardBlock } from './CardBlock';
@@ -43,7 +46,12 @@ export const PlayerStatCounterGrid = ({
   }
 
   return (
-    <div className={styles.rootContainer}>
+    <div
+      className={styles.rootContainer}
+      style={assignInlineVars({
+        [teamColor]: team.teamColor,
+      })}
+    >
       <PlayerBlock team={team} player={player} />
       <div className={styles.mainContainer}>
         <div className={styles.statContainer}>

--- a/src/components/SubstitutionPlayerList/SubstitutionPlayerList.css.ts
+++ b/src/components/SubstitutionPlayerList/SubstitutionPlayerList.css.ts
@@ -3,6 +3,7 @@ import { style } from '@vanilla-extract/css';
 import { lightThemeVars } from '@/styles/theme.css';
 
 export const rootContainer = style({
+  boxSizing: 'border-box',
   display: 'flex',
   flexDirection: 'column',
   border: `1px solid ${lightThemeVars.color.primary['100']}`,

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.css.ts
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.css.ts
@@ -4,5 +4,5 @@ export const container = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 24,
-  padding: [22, 20],
+  padding: '22px 20px',
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,6 @@ export * from './GameScoreArea';
 export * from './TinyBarChart';
 export * from './StatCompareCounter';
 export * from './TeamStatCompareCounterList';
+export * from './MatchLogList';
+export * from './MatchSchedule';
+export * from './MatchRecordSimpleMemo';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,4 +13,3 @@ export * from './StatCompareCounter';
 export * from './TeamStatCompareCounterList';
 export * from './MatchLogList';
 export * from './MatchSchedule';
-export * from './MatchRecordSimpleMemo';

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet, createRootRoute } from '@tanstack/react-router';
+import { Outlet, createRootRoute } from '@tanstack/react-router';
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 
 export const Route = createRootRoute({
@@ -8,11 +8,6 @@ export const Route = createRootRoute({
 function Root() {
   return (
     <>
-      <div>
-        <h1>Matchday</h1>
-        <Link to='/'>Home</Link> <Link to='/about'>About</Link>
-      </div>
-      <hr />
       <Outlet />
       <TanStackRouterDevtools />
     </>

--- a/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.css.ts
+++ b/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
+import { lightThemeVars } from '@/styles/theme.css';
+
 // NOTE: 현재 디자인은 고정 크기의 레이아웃으로 배치
 export const rootContainer = style({
   display: 'flex',
@@ -13,6 +15,7 @@ export const rootContainer = style({
   },
   gap: 16,
   margin: '0 16px',
+  backgroundColor: lightThemeVars.color.gray[100],
   minWidth: 1380,
   height: 964,
 });

--- a/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.tsx
+++ b/src/routes/matches/record/-components/MatchRecordLayout/MatchRecordLayout.tsx
@@ -1,5 +1,12 @@
 import { ReactNode } from 'react';
 
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
+import {
+  teamAwayColor,
+  teamHomeColor,
+} from '@/components/MatchLogList/colors.css';
+
 import * as styles from './MatchRecordLayout.css';
 
 interface MatchRecordLayoutProps {
@@ -11,6 +18,8 @@ interface MatchRecordLayoutProps {
   info: ReactNode;
   log: ReactNode;
   memo: ReactNode;
+  team1Color: string;
+  team2Color: string;
 }
 
 export const MatchRecordLayout = ({
@@ -22,9 +31,17 @@ export const MatchRecordLayout = ({
   timer,
   log,
   memo,
+  team1Color,
+  team2Color,
 }: MatchRecordLayoutProps) => {
   return (
-    <div className={styles.rootContainer}>
+    <div
+      className={styles.rootContainer}
+      style={assignInlineVars({
+        [teamHomeColor]: team1Color,
+        [teamAwayColor]: team2Color,
+      })}
+    >
       <div className={styles.teamContainer}>{team1}</div>
       <div className={styles.centerContainer}>
         {teamStats}

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { createFileRoute } from '@tanstack/react-router';
 
 import { StartingPlayer } from '@/apis';
@@ -110,6 +112,7 @@ const s = (height: number | string) => ({
 
 function MatchRecordPage() {
   const now = getUnixTimestampInSeconds();
+  const [memo, setMemo] = useState('');
 
   return (
     <MatchRecordLayout
@@ -274,10 +277,7 @@ function MatchRecordPage() {
       }
       memo={
         <div style={s(204)}>
-          <MatchRecordSimpleMemo
-            value={'간편 메모 테스트'}
-            onChange={() => {}}
-          />
+          <MatchRecordSimpleMemo value={memo} onChange={setMemo} />
         </div>
       }
     />

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -4,6 +4,9 @@ import { StartingPlayer } from '@/apis';
 import { Team } from '@/apis';
 import {
   GameScoreArea,
+  MatchLogList,
+  MatchRecordSimpleMemo,
+  MatchSchedule,
   MatchTimeController,
   PlayerList,
   PlayerStatCounterGrid,
@@ -11,9 +14,6 @@ import {
   TeamStatCompareCounterList,
   TeamStatCounterGrid,
 } from '@/components';
-import { MatchLogList } from '@/components/MatchLogList';
-import MatchRecordSimpleMemo from '@/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo';
-import { MatchSchedule } from '@/components/MatchSchedule';
 import {
   getTimeAgo,
   getUnixTimestampInSeconds,

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -1,7 +1,25 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import { PlayerList } from '@/components';
+import { StartingPlayer } from '@/apis';
+import { Team } from '@/apis';
+import {
+  GameScoreArea,
+  MatchTimeController,
+  PlayerList,
+  PlayerStatCounterGrid,
+  SubstitutionPlayerList,
+  TeamStatCompareCounterList,
+  TeamStatCounterGrid,
+} from '@/components';
+import { MatchLogList } from '@/components/MatchLogList';
+import MatchRecordSimpleMemo from '@/components/MatchRecordSimpleMemo/MatchRecordSimpleMemo';
+import { MatchSchedule } from '@/components/MatchSchedule';
+import {
+  getTimeAgo,
+  getUnixTimestampInSeconds,
+} from '@/components/MatchTimeController/timeUtils';
 import { dummyPlayerOfTeam1, dummyTeam1, dummyTeam2 } from '@/mocks';
+import { lightThemeVars } from '@/styles/theme.css';
 
 import { MatchRecordLayout } from './-components';
 
@@ -9,34 +27,256 @@ export const Route = createFileRoute('/matches/record')({
   component: MatchRecordPage,
 });
 
+const mockHomeTeam: Team = {
+  id: 1,
+  name: 'FC 서울',
+  teamColor: lightThemeVars.color.soccer.red,
+  logoImageUrl: 'https://example.com/logo1.png',
+};
+
+const mockAwayTeam: Team = {
+  id: 2,
+  name: '수원 삼성',
+  teamColor: '#003A70',
+  logoImageUrl: 'https://example.com/logo2.png',
+};
+
+const mockHomePlayer: StartingPlayer = {
+  id: 1,
+  name: '홍길동',
+  number: 10,
+  position: 'FW',
+  profileImageUrl: 'https://example.com/profile1.png',
+  goals: 10,
+  assists: 10,
+  fouls: 10,
+  yellowCards: 0,
+  redCards: 0,
+};
+
+const mockAwayPlayer: StartingPlayer = {
+  id: 2,
+  name: '이순신',
+  number: 10,
+  position: 'FW',
+  profileImageUrl: 'https://example.com/profile2.png',
+  goals: 10,
+  assists: 10,
+  fouls: 10,
+  yellowCards: 0,
+  redCards: 0,
+};
+
+const mockLogs = Array.from({ length: 10 }, (_, index) => [
+  {
+    id: index * 3 + 1,
+    time: new Date('2024-01-01'),
+    team: mockHomeTeam,
+    player: mockHomePlayer,
+    action: '유효 슈팅',
+  },
+  {
+    id: index * 3 + 2,
+    time: new Date('2024-01-01'),
+    team: mockAwayTeam,
+    player: mockAwayPlayer,
+    action: '골',
+  },
+  {
+    id: index * 3 + 3,
+    time: new Date('2024-01-01'),
+    team: mockHomeTeam,
+    player: mockHomePlayer,
+    action: '골',
+  },
+]).flat();
+
+const statFields = [
+  '슈팅',
+  '유효 슈팅',
+  '코너킥',
+  '오프사이드',
+  '파울',
+  '경고',
+];
+
 // TO DO: 예시용 스타일로, 추후 제거 필요
 const s = (height: number | string) => ({
   height,
-  backgroundColor: '#F2F3F7',
-  boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
+  backgroundColor: '#fff',
   borderRadius: 10,
-  borderBottom: '1px solid #E5E5EC',
 });
 
 function MatchRecordPage() {
+  const now = getUnixTimestampInSeconds();
+
   return (
     <MatchRecordLayout
+      team1Color={dummyTeam1.teamColor}
+      team2Color={dummyTeam2.teamColor}
       team1={
-        <div style={s('100%')}>
+        <div
+          style={{
+            ...s('auto'),
+            marginTop: 18,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <PlayerList team={dummyTeam1} players={dummyPlayerOfTeam1} />
+          <div
+            style={{
+              padding: '24px 8px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 20,
+            }}
+          >
+            <SubstitutionPlayerList
+              players={[
+                { number: '7', name: '손흥민', position: 'FW' },
+                { number: '10', name: '이강인', position: 'MF' },
+                { number: '4', name: '김민재', position: 'DF' },
+                { number: '1', name: '김승규', position: 'GK' },
+                { number: '11', name: '황희찬', position: 'FW' },
+                { number: '6', name: '황인범', position: 'MF' },
+                { number: '3', name: '김진수', position: 'DF' },
+              ]}
+            />
+            <TeamStatCounterGrid
+              stats={statFields.map(title => ({
+                title,
+                value: Math.floor(Math.random() * 30),
+              }))}
+            />
+          </div>
         </div>
       }
       team2={
-        <div style={s('100%')}>
+        <div
+          style={{
+            ...s('auto'),
+            marginTop: 18,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <PlayerList team={dummyTeam2} players={dummyPlayerOfTeam1} />
+          <div
+            style={{
+              padding: '24px 8px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 20,
+            }}
+          >
+            <SubstitutionPlayerList
+              players={[
+                { number: '7', name: '손흥민', position: 'FW' },
+                { number: '10', name: '이강인', position: 'MF' },
+                { number: '4', name: '김민재', position: 'DF' },
+                { number: '1', name: '김승규', position: 'GK' },
+                { number: '11', name: '황희찬', position: 'FW' },
+                { number: '6', name: '황인범', position: 'MF' },
+                { number: '3', name: '김진수', position: 'DF' },
+              ]}
+            />
+            <TeamStatCounterGrid
+              stats={statFields.map(title => ({
+                title,
+                value: Math.floor(Math.random() * 30),
+              }))}
+            />
+          </div>
         </div>
       }
-      teamStats={<div style={s(528)}>Stats</div>}
-      selectedPlayer={<div style={s(302)}>Selected Player</div>}
-      timer={<div style={s(116)}>Timer</div>}
-      info={<div style={s(200)}>Info</div>}
-      log={<div style={s(264)}>Log</div>}
-      memo={<div style={s(204)}>Memo</div>}
+      teamStats={
+        <div style={s(548)}>
+          <GameScoreArea
+            scores={{
+              home: 0,
+              away: 0,
+            }}
+            homeTeam={dummyTeam1}
+            awayTeam={dummyTeam2}
+          />
+          <TeamStatCompareCounterList
+            homeTeamStat={{
+              슈팅: 30,
+              '유효 슈팅': 25,
+              '코너 킥': 15,
+              '오프 사이드': 8,
+              파울: 20,
+              경고: 5,
+            }}
+            awayTeamStat={{
+              슈팅: 20,
+              '유효 슈팅': 10,
+              '코너 킥': 12,
+              '오프 사이드': 6,
+              파울: 15,
+              경고: 4,
+            }}
+            maxValue={30}
+          />
+        </div>
+      }
+      selectedPlayer={
+        <div style={s(302)}>
+          <PlayerStatCounterGrid
+            player={dummyPlayerOfTeam1[0]}
+            team={dummyTeam1}
+          />
+        </div>
+      }
+      timer={
+        <div style={s(116)}>
+          <MatchTimeController
+            now={now}
+            matchStatus={{
+              currentPeriod: 1,
+              state: 'playing',
+              startedAt: getTimeAgo({ minutes: 50, seconds: 0, now }),
+              addedTime: 5,
+            }}
+            periodNames={['전반', '후반']}
+          />
+        </div>
+      }
+      info={
+        <div style={s(284)}>
+          <MatchSchedule
+            items={[
+              { label: '장소', value: '한양대학교 대운동장' },
+              { label: '날짜', value: '2025-04-16 (수)' },
+              { label: '시간', value: '09 : 30 ~ 11 : 30' },
+              { label: '주심', value: '김태인' },
+              { label: '부심1', value: '김주용' },
+              { label: '부심2', value: '주유나' },
+              { label: '대기심', value: '김성빈' },
+            ]}
+          />
+        </div>
+      }
+      log={
+        <div style={s(228)}>
+          <MatchLogList
+            teams={{
+              home: dummyTeam1,
+              away: dummyTeam2,
+            }}
+            logs={mockLogs}
+          />
+        </div>
+      }
+      memo={
+        <div style={s(204)}>
+          <MatchRecordSimpleMemo
+            value={'간편 메모 테스트'}
+            onChange={() => {}}
+          />
+        </div>
+      }
     />
   );
 }

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -19,6 +19,7 @@ import {
   getUnixTimestampInSeconds,
 } from '@/components/MatchTimeController/timeUtils';
 import { dummyPlayerOfTeam1, dummyTeam1, dummyTeam2 } from '@/mocks';
+import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
 import { MatchRecordLayout } from './-components';
@@ -116,6 +117,7 @@ function MatchRecordPage() {
       team2Color={dummyTeam2.teamColor}
       team1={
         <div
+          className={commonPaper}
           style={{
             ...s('auto'),
             marginTop: 18,
@@ -154,6 +156,7 @@ function MatchRecordPage() {
       }
       team2={
         <div
+          className={commonPaper}
           style={{
             ...s('auto'),
             marginTop: 18,
@@ -191,7 +194,7 @@ function MatchRecordPage() {
         </div>
       }
       teamStats={
-        <div style={s(548)}>
+        <div className={commonPaper} style={s(548)}>
           <GameScoreArea
             scores={{
               home: 0,

--- a/src/styles/paper.css.ts
+++ b/src/styles/paper.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from './theme.css';
+
+export const commonPaper = style({
+  borderRadius: 10,
+  boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
+  background: lightThemeVars.color.white.main,
+});


### PR DESCRIPTION
## Description

- [Jira: MAT-122](https://match-day.atlassian.net/browse/MAT-122)
- 경기 기록 페이지 레이아웃 퍼블리싱

## Changes

- [x] `routes/matches/record/route.tsx`에서 기본적인 레이아웃 구성
- [x] 소속 컴포넌트들의 디자인 오차 수정
- [x] 누락된 components barrel file export 추가
- [x] 경기 기록 페이지의 그림자 효과 공통화

### Screenshots

<img width="1364" alt="image" src="https://github.com/user-attachments/assets/41cb0176-2757-4ec5-a47a-8b2010d3a90f" />

https://github.com/user-attachments/assets/59410553-0a32-40d4-9a93-f03d05737c95

## To-do

- [ ] 서버 상태 식별해 전체적인 props 구조 결정 (서버 API - TBD)
- [ ] Layout 역할의 로컬 컴포넌트 분리
- [ ] mock 데이터 정리
- [ ] 선발 선수 격자 구현
- [ ] 선발 선수 - 격자 <-> 리스트 토글 구현