### PR TITLE
feat: MAT-138 선택된 선수 상태를 전역 상태로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@vanilla-extract/sprinkles": "^1.6.3",
     "ky": "^1.8.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@antebudimir/eslint-plugin-vanilla-extract": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      zustand:
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@19.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@antebudimir/eslint-plugin-vanilla-extract':
         specifier: ^1.8.0
@@ -3580,6 +3583,24 @@ packages:
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
+  zustand@5.0.4:
+    resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -7290,3 +7311,9 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   zod@3.24.2: {}
+
+  zustand@5.0.4(@types/react@19.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+    optionalDependencies:
+      '@types/react': 19.1.1
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)

--- a/src/components/PlayerList/PlayerList.stories.tsx
+++ b/src/components/PlayerList/PlayerList.stories.tsx
@@ -21,63 +21,21 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const mockPlayer = {
-  name: '김철수',
-  number: 7,
-  position: 'FW',
-  profileImageUrl: 'https://example.com/player1.png',
-  goals: 2,
-  assists: 1,
-  fouls: 0,
-  yellowCards: 0,
-  redCards: 0,
-};
-
-const createMockPlayers = (count: number) => {
-  return Array.from({ length: count }, (_, index) => ({
-    ...mockPlayer,
-    id: index + 1,
-  }));
-};
-
 export const Default: Story = {
   args: {
-    team: {
-      id: 1,
-      name: 'FC 서울',
-      teamColor: '#FF0000',
-      logoImageUrl: 'https://example.com/logo.png',
-    },
-    players: createMockPlayers(2),
-    selectedPlayerId: 1,
-    onPlayerSelect: () => {},
+    teamType: 'home',
   },
 };
 
 export const FullPlayers: Story = {
   args: {
-    team: {
-      id: 2,
-      name: '수원 삼성',
-      teamColor: '#0000FF',
-      logoImageUrl: 'https://example.com/logo2.png',
-    },
-    players: createMockPlayers(20),
-    selectedPlayerId: 1,
-    onPlayerSelect: () => {},
+    teamType: 'home',
   },
 };
 
+// FIXME: 추후 msw 모킹으로 재현 필요
 export const EmptyPlayers: Story = {
   args: {
-    team: {
-      id: 2,
-      name: '수원 삼성',
-      teamColor: '#0000FF',
-      logoImageUrl: 'https://example.com/logo2.png',
-    },
-    players: [],
-    selectedPlayerId: 1,
-    onPlayerSelect: () => {},
+    teamType: 'away',
   },
 };

--- a/src/components/PlayerList/PlayerList.tsx
+++ b/src/components/PlayerList/PlayerList.tsx
@@ -2,26 +2,24 @@ import { SyntheticEvent } from 'react';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-import { StartingPlayer, Team } from '@/apis';
+import { StartingPlayerOnGrid } from '@/apis';
 import noProfilePlayerImage from '@/assets/images/noProfilePlayer.png';
+import { mocked_getPlayersByTeamType, mocked_getTeamByType } from '@/mocks';
+import { TeamType, useSelectedPlayerStore } from '@/stores';
 
 import * as styles from './PlayerList.css';
 import { PlayerItem } from './PlayerListItem';
 import { teamColor } from './TeamColor.css';
 
 interface PlayerListProps {
-  team: Team;
-  players: StartingPlayer[];
-  selectedPlayerId: number | null;
-  onPlayerSelect: (playerId: number) => void;
+  teamType: TeamType;
 }
 
-export const PlayerList = ({
-  team,
-  players,
-  selectedPlayerId,
-  onPlayerSelect,
-}: PlayerListProps) => {
+export const PlayerList = ({ teamType }: PlayerListProps) => {
+  // TODO: Tanstack-query 연동
+  const team = mocked_getTeamByType(teamType);
+  const players = mocked_getPlayersByTeamType(teamType);
+
   const setFallbackImageIfLoadFail = (
     e: SyntheticEvent<HTMLImageElement, Event>,
   ) => {
@@ -52,11 +50,7 @@ export const PlayerList = ({
         </div>
       </div>
       {players.length > 0 ? (
-        <PlayerListContent
-          players={players}
-          selectedPlayerId={selectedPlayerId}
-          onPlayerSelect={onPlayerSelect}
-        />
+        <PlayerListContent teamType={teamType} players={players} />
       ) : (
         <EmptyContent />
       )}
@@ -65,25 +59,27 @@ export const PlayerList = ({
 };
 
 const PlayerListContent = ({
+  teamType,
   players,
-  selectedPlayerId,
-  onPlayerSelect,
 }: {
-  players: StartingPlayer[];
-  selectedPlayerId: number | null;
-  onPlayerSelect: (playerId: number) => void;
-}) => (
-  <ul className={styles.playerListContainer}>
-    {players.map(player => (
-      <PlayerItem
-        key={player.id}
-        player={player}
-        isSelected={selectedPlayerId === player.id}
-        onClick={() => onPlayerSelect(player.id)}
-      />
-    ))}
-  </ul>
-);
+  teamType: TeamType;
+  players: StartingPlayerOnGrid[];
+}) => {
+  const { isSelected, selectedPlayer, selectPlayer } = useSelectedPlayerStore();
+
+  return (
+    <ul className={styles.playerListContainer}>
+      {players.map(player => (
+        <PlayerItem
+          key={player.id}
+          player={player}
+          isSelected={isSelected && selectedPlayer.id === player.id}
+          onClick={() => selectPlayer({ teamType, id: player.id })}
+        />
+      ))}
+    </ul>
+  );
+};
 
 const EmptyContent = () => (
   <div className={styles.emptyContainer}>

--- a/src/components/PlayerList/PlayerList.tsx
+++ b/src/components/PlayerList/PlayerList.tsx
@@ -12,7 +12,7 @@ import { teamColor } from './TeamColor.css';
 interface PlayerListProps {
   team: Team;
   players: StartingPlayer[];
-  selectedPlayerId: number;
+  selectedPlayerId: number | null;
   onPlayerSelect: (playerId: number) => void;
 }
 
@@ -70,7 +70,7 @@ const PlayerListContent = ({
   onPlayerSelect,
 }: {
   players: StartingPlayer[];
-  selectedPlayerId: number;
+  selectedPlayerId: number | null;
   onPlayerSelect: (playerId: number) => void;
 }) => (
   <ul className={styles.playerListContainer}>

--- a/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.stories.tsx
+++ b/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.stories.tsx
@@ -1,8 +1,4 @@
-import { useState } from 'react';
-
 import type { Meta, StoryObj } from '@storybook/react';
-
-import { StartingPlayerOnGrid } from '@/apis';
 
 import { PlayerOnFieldGrid } from './PlayerOnFieldGrid';
 
@@ -25,59 +21,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const gridPositions = [2, 5, 7, 9, 11, 13, 17, 21, 22, 23, 27];
-
-const mockPlayers: StartingPlayerOnGrid[] = Array.from(
-  { length: 11 },
-  (_, idx) => ({
-    id: idx + 1,
-    name: '손흥민',
-    number: 99,
-    position: 'FW',
-    profileImageUrl: 'https://via.placeholder.com/150',
-    goals: Math.max(0, 5 - idx),
-    assists: Math.max(0, idx - 5),
-    fouls: 2,
-    yellowCards: idx % 2 === 0 ? 1 : 0,
-    redCards: idx % 3 === 0 ? 1 : 0,
-    grid: gridPositions[idx],
-  }),
-);
-
 export const Default: Story = {
   args: {
-    players: mockPlayers,
-    selectedPlayerId: 1,
-    onPlayerSelect: () => {},
-  },
-};
-
-export const WithSelectedPlayer: Story = {
-  args: {
-    players: mockPlayers,
-    selectedPlayerId: 1,
-    onPlayerSelect: () => {},
-  },
-};
-
-export const Selectable: Story = {
-  args: {
-    players: mockPlayers,
-    selectedPlayerId: 1,
-    onPlayerSelect: () => {},
-  },
-  render: () => {
-    const defaultSelectedPlayerId = 1;
-    const [selectedPlayerId, setSelectedPlayerId] = useState<number>(
-      defaultSelectedPlayerId,
-    );
-
-    return (
-      <PlayerOnFieldGrid
-        players={mockPlayers}
-        selectedPlayerId={selectedPlayerId}
-        onPlayerSelect={setSelectedPlayerId}
-      />
-    );
+    teamType: 'home',
   },
 };

--- a/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.tsx
+++ b/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.tsx
@@ -6,7 +6,7 @@ import * as styles from './PlayerOnFieldGrid.css';
 
 interface PlayerOnFieldGridProps {
   players: StartingPlayerOnGrid[];
-  selectedPlayerId: number;
+  selectedPlayerId: number | null;
   onPlayerSelect: (playerId: number) => void;
 }
 

--- a/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.tsx
+++ b/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.tsx
@@ -1,22 +1,22 @@
-import { StartingPlayerOnGrid } from '@/apis/players';
+import { mocked_getPlayersByTeamType } from '@/mocks';
+import { TeamType, useSelectedPlayerStore } from '@/stores';
 
 import { FieldBackground } from './FieldBackground';
 import { EmptyOnFieldGridCell, PlayerOnFieldGridCell } from './FieldGridCell';
 import * as styles from './PlayerOnFieldGrid.css';
 
-interface PlayerOnFieldGridProps {
-  players: StartingPlayerOnGrid[];
-  selectedPlayerId: number | null;
-  onPlayerSelect: (playerId: number) => void;
-}
-
 const TOTAL_CELLS = 30;
 
-export const PlayerOnFieldGrid = ({
-  players,
-  selectedPlayerId,
-  onPlayerSelect,
-}: PlayerOnFieldGridProps) => {
+interface PlayerOnFieldGridProps {
+  teamType: TeamType;
+}
+
+export const PlayerOnFieldGrid = ({ teamType }: PlayerOnFieldGridProps) => {
+  const { isSelected, selectedPlayer, selectPlayer } = useSelectedPlayerStore();
+
+  // TODO: Tanstack-query 연동
+  const players = mocked_getPlayersByTeamType(teamType);
+
   const playerGridMap = new Map(players.map(player => [player.grid, player]));
 
   return (
@@ -33,9 +33,9 @@ export const PlayerOnFieldGrid = ({
             <PlayerOnFieldGridCell
               key={idx}
               player={player}
-              isSelected={player.id === selectedPlayerId}
+              isSelected={isSelected && selectedPlayer.id === player.id}
               onClick={() => {
-                onPlayerSelect?.(player.id);
+                selectPlayer({ teamType, id: player.id });
               }}
             />
           );

--- a/src/components/PlayerStatCounterGrid/PlayerBlock/PlayerBlock.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerBlock/PlayerBlock.tsx
@@ -5,8 +5,8 @@ import noProfilePlayerImage from '@/assets/images/noProfilePlayer.png';
 
 import * as styles from './PlayerBlock.css';
 
-export interface ListItemProps {
-  team: Team;
+export interface PlayerBlockProps {
+  team?: Team;
   player: StartingPlayer;
 }
 
@@ -18,9 +18,11 @@ const setFallbackImageIfLoadFail = (
 };
 
 export const PlayerBlock = ({
-  team: { logoImageUrl },
+  team,
   player: { number, name, position, profileImageUrl },
-}: ListItemProps) => {
+}: PlayerBlockProps) => {
+  const logoImageUrl = team?.logoImageUrl;
+
   return (
     <li className={styles.rootContainer}>
       <div className={styles.leftContainer}>

--- a/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.stories.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 import { teamColor } from '@/components/PlayerList/TeamColor.css';
+import { useSelectedPlayerStore } from '@/stores';
 import { lightThemeVars } from '@/styles/theme.css';
 
 import { PlayerStatCounterGrid } from './PlayerStatCounterGrid';
@@ -32,53 +33,41 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const dummyTeam = {
-  logoImageUrl: 'https://via.placeholder.com/150',
-  id: 1,
-  name: '홍길동',
-  teamColor: '#000000',
-};
+export const Unselected: Story = {
+  decorators: [
+    Story => {
+      useSelectedPlayerStore.setState({
+        isSelected: false,
+        selectedPlayer: undefined,
+      });
 
-const dummyPlayer = {
-  number: 91,
-  name: '홍길동',
-  position: 'FW',
-  profileImageUrl: 'https://via.placeholder.com/150',
-  goals: 10,
-  assists: 5,
-  fouls: 3,
-  id: 1,
-  yellowCards: 0,
-  redCards: 0,
-};
-
-export const Default: Story = {
-  args: {
-    team: dummyTeam,
-    player: dummyPlayer,
-  },
-};
-
-export const NotSelected: Story = {
-  args: {},
+      return <Story />;
+    },
+  ],
 };
 
 export const OneYellowCard: Story = {
-  args: {
-    team: dummyTeam,
-    player: {
-      ...dummyPlayer,
-      yellowCards: 1,
+  decorators: [
+    Story => {
+      useSelectedPlayerStore.setState({
+        isSelected: true,
+        selectedPlayer: { teamType: 'home', id: 3 },
+      });
+
+      return <Story />;
     },
-  },
+  ],
 };
 
 export const OneRedCard: Story = {
-  args: {
-    team: dummyTeam,
-    player: {
-      ...dummyPlayer,
-      redCards: 1,
+  decorators: [
+    Story => {
+      useSelectedPlayerStore.setState({
+        isSelected: true,
+        selectedPlayer: { teamType: 'home', id: 1 },
+      });
+
+      return <Story />;
     },
-  },
+  ],
 };

--- a/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.tsx
@@ -2,31 +2,37 @@ import { useState } from 'react';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-import { StartingPlayer, Team } from '@/apis';
 import { teamColor } from '@/components/PlayerList/TeamColor.css';
 import { StatCounterItem } from '@/components/StatCounterItem';
+import { mocked_getPlayersByTeamType } from '@/mocks';
+import { mocked_getTeamByType } from '@/mocks';
+import { useSelectedPlayerStore } from '@/stores';
 
 import { CardBlock } from './CardBlock';
 import { NotSelected } from './NotSelected';
 import { PlayerBlock } from './PlayerBlock';
 import * as styles from './PlayerStatCounterGrid.css';
 
-interface PlayerStatCounterGridProps {
-  team?: Team;
-  player?: StartingPlayer;
-}
-
 const statFields = ['득점', '어시스트'];
 
-export const PlayerStatCounterGrid = ({
-  team,
-  player,
-}: PlayerStatCounterGridProps) => {
-  // NOTE: DEMO 용도로만 임시로 로컬 상태 사용
-  const [goals, setGoals] = useState(player?.goals ?? 0);
-  const [assists, setAssists] = useState(player?.assists ?? 0);
-  const [yellowCards, setYellowCards] = useState(player?.yellowCards ?? 0);
-  const [redCards, setRedCards] = useState(player?.redCards ?? 0);
+export const PlayerStatCounterGrid = () => {
+  const { isSelected, selectedPlayer } = useSelectedPlayerStore();
+
+  // TODO: Tanstack-query 연동
+  const team = isSelected
+    ? mocked_getTeamByType(selectedPlayer.teamType)
+    : undefined;
+  const actualSelectedPlayer = isSelected
+    ? mocked_getPlayersByTeamType(selectedPlayer.teamType).find(
+        player => player.id === selectedPlayer.id,
+      )
+    : undefined;
+  const [goals, setGoals] = useState(actualSelectedPlayer?.goals ?? 0);
+  const [assists, setAssists] = useState(actualSelectedPlayer?.assists ?? 0);
+  const [yellowCards, setYellowCards] = useState(
+    actualSelectedPlayer?.yellowCards ?? 0,
+  );
+  const [redCards, setRedCards] = useState(actualSelectedPlayer?.redCards ?? 0);
 
   const isYellow = yellowCards > 0;
   const isRed = redCards > 0;
@@ -41,7 +47,7 @@ export const PlayerStatCounterGrid = ({
     }
   };
 
-  if (!team || !player) {
+  if (!actualSelectedPlayer) {
     return <NotSelected />;
   }
 
@@ -49,10 +55,10 @@ export const PlayerStatCounterGrid = ({
     <div
       className={styles.rootContainer}
       style={assignInlineVars({
-        [teamColor]: team.teamColor,
+        [teamColor]: team?.teamColor,
       })}
     >
-      <PlayerBlock team={team} player={player} />
+      <PlayerBlock team={team} player={actualSelectedPlayer} />
       <div className={styles.mainContainer}>
         <div className={styles.statContainer}>
           {statFields.map(title => (

--- a/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.stories.tsx
+++ b/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.stories.tsx
@@ -1,8 +1,4 @@
-import { useState } from 'react';
-
 import type { Meta, StoryObj } from '@storybook/react';
-
-import { gridMockPlayers } from '@/mocks';
 
 import { ToggleableStartingPlayers } from './ToggleableStartingPlayers';
 
@@ -27,43 +23,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    team: {
-      id: 1,
-      name: '홈팀',
-      logoImageUrl: 'https://via.placeholder.com/150',
-      teamColor: '#000000',
-    },
-    players: gridMockPlayers,
-    selectedPlayerId: 1,
-    onPlayerSelect: playerId => {
-      console.log('선수 선택:', playerId);
-    },
-  },
-};
-
-export const Toggleable: Story = {
-  args: {
-    team: {
-      id: 2,
-      name: '원정팀',
-      logoImageUrl: 'https://via.placeholder.com/150',
-      teamColor: '#000000',
-    },
-    players: gridMockPlayers,
-    selectedPlayerId: 2,
-    onPlayerSelect: () => {},
-  },
-  render: args => {
-    const [selectedPlayerId, setSelectedPlayerId] = useState(
-      args.selectedPlayerId,
-    );
-
-    return (
-      <ToggleableStartingPlayers
-        {...args}
-        selectedPlayerId={selectedPlayerId}
-        onPlayerSelect={setSelectedPlayerId}
-      />
-    );
+    teamType: 'home',
   },
 };

--- a/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.tsx
+++ b/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.tsx
@@ -1,22 +1,18 @@
 import { useState } from 'react';
 
-import { StartingPlayerOnGrid, Team } from '@/apis';
 import { PlayerList } from '@/components/PlayerList';
 import { PlayerOnFieldGrid } from '@/components/PlayerOnFieldGrid';
+import { TeamType } from '@/stores';
 
 import * as styles from './ToggleableStartingPlayers.css';
 
+interface ToggleableStartingPlayersProps {
+  teamType: TeamType;
+}
+
 export const ToggleableStartingPlayers = ({
-  team,
-  players,
-  selectedPlayerId,
-  onPlayerSelect,
-}: {
-  team: Team;
-  players: StartingPlayerOnGrid[];
-  selectedPlayerId: number | null;
-  onPlayerSelect: (playerId: number) => void;
-}) => {
+  teamType,
+}: ToggleableStartingPlayersProps) => {
   const [isGridView, setIsGridView] = useState(true);
 
   return (
@@ -28,18 +24,9 @@ export const ToggleableStartingPlayers = ({
         {isGridView ? '리스트 보기' : '포메이션 보기'}
       </button>
       {isGridView ? (
-        <PlayerOnFieldGrid
-          players={players}
-          selectedPlayerId={selectedPlayerId}
-          onPlayerSelect={onPlayerSelect}
-        />
+        <PlayerOnFieldGrid teamType={teamType} />
       ) : (
-        <PlayerList
-          team={team}
-          players={players}
-          selectedPlayerId={selectedPlayerId}
-          onPlayerSelect={onPlayerSelect}
-        />
+        <PlayerList teamType={teamType} />
       )}
     </div>
   );

--- a/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.tsx
+++ b/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.tsx
@@ -14,7 +14,7 @@ export const ToggleableStartingPlayers = ({
 }: {
   team: Team;
   players: StartingPlayerOnGrid[];
-  selectedPlayerId: number;
+  selectedPlayerId: number | null;
   onPlayerSelect: (playerId: number) => void;
 }) => {
   const [isGridView, setIsGridView] = useState(true);

--- a/src/mocks/getTeamByType.ts
+++ b/src/mocks/getTeamByType.ts
@@ -1,0 +1,31 @@
+import { TeamType } from '@/stores';
+
+import { dummyTeam1, dummyTeam2 } from './startingPlayers';
+
+export const mocked_getTeamByType = (teamType: TeamType) => {
+  if (teamType === 'home') {
+    return dummyTeam1;
+  }
+
+  return dummyTeam2;
+};
+
+const gridPositions = [2, 5, 7, 9, 11, 13, 17, 21, 22, 23, 27];
+
+export const mocked_getPlayersByTeamType = (teamType: TeamType) => {
+  const startingIdx = teamType === 'home' ? 0 : 11;
+
+  return Array.from({ length: 11 }, (_, idx) => ({
+    id: startingIdx + 1 + idx,
+    name: '손흥민',
+    number: 99,
+    position: 'FW',
+    profileImageUrl: 'https://via.placeholder.com/150',
+    goals: Math.max(0, 5 - idx),
+    assists: Math.max(0, idx - 5),
+    fouls: 2,
+    yellowCards: idx % 2 === 0 ? 1 : 0,
+    redCards: idx % 3 === 0 ? 1 : 0,
+    grid: gridPositions[idx],
+  }));
+};

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,3 +1,4 @@
 export * from './startingPlayers';
 export * from './api';
 export * from './startingPlayersOnGrid';
+export * from './getTeamByType';

--- a/src/mocks/startingPlayers.ts
+++ b/src/mocks/startingPlayers.ts
@@ -4,6 +4,7 @@ export const dummyTeam1 = {
   teamColor: '#D91920',
   logoImageUrl: '/images/team-logo.png',
 };
+
 export const dummyTeam2 = {
   id: 2,
   name: 'FC 독도',

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -20,8 +20,7 @@ import {
   getTimeAgo,
   getUnixTimestampInSeconds,
 } from '@/components/MatchTimeController/timeUtils';
-import { dummyTeam1, dummyTeam2, gridMockPlayers } from '@/mocks';
-import { useSelectedPlayerStore } from '@/stores';
+import { dummyTeam1, dummyTeam2 } from '@/mocks';
 import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
@@ -114,7 +113,6 @@ const s = (height: number | string) => ({
 function MatchRecordPage() {
   const now = getUnixTimestampInSeconds();
   const [memo, setMemo] = useState('');
-  const { selectedPlayerId, setSelectedPlayerId } = useSelectedPlayerStore();
 
   return (
     <MatchRecordLayout
@@ -129,12 +127,7 @@ function MatchRecordPage() {
             flexDirection: 'column',
           }}
         >
-          <ToggleableStartingPlayers
-            team={dummyTeam1}
-            players={gridMockPlayers}
-            selectedPlayerId={selectedPlayerId}
-            onPlayerSelect={setSelectedPlayerId}
-          />
+          <ToggleableStartingPlayers teamType='home' />
           <div
             style={{
               padding: '24px 8px',
@@ -172,12 +165,7 @@ function MatchRecordPage() {
             flexDirection: 'column',
           }}
         >
-          <ToggleableStartingPlayers
-            team={dummyTeam2}
-            players={gridMockPlayers}
-            selectedPlayerId={selectedPlayerId}
-            onPlayerSelect={setSelectedPlayerId}
-          />
+          <ToggleableStartingPlayers teamType='away' />
           <div
             style={{
               padding: '24px 8px',
@@ -239,12 +227,7 @@ function MatchRecordPage() {
       }
       selectedPlayer={
         <div style={s(302)}>
-          <PlayerStatCounterGrid
-            player={gridMockPlayers.find(
-              player => player.id === selectedPlayerId,
-            )}
-            team={dummyTeam1}
-          />
+          <PlayerStatCounterGrid />
         </div>
       }
       timer={

--- a/src/routes/matches/record/route.tsx
+++ b/src/routes/matches/record/route.tsx
@@ -21,6 +21,7 @@ import {
   getUnixTimestampInSeconds,
 } from '@/components/MatchTimeController/timeUtils';
 import { dummyTeam1, dummyTeam2, gridMockPlayers } from '@/mocks';
+import { useSelectedPlayerStore } from '@/stores';
 import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
@@ -113,7 +114,7 @@ const s = (height: number | string) => ({
 function MatchRecordPage() {
   const now = getUnixTimestampInSeconds();
   const [memo, setMemo] = useState('');
-  const [selectedPlayerId, setSelectedPlayerId] = useState(-1);
+  const { selectedPlayerId, setSelectedPlayerId } = useSelectedPlayerStore();
 
   return (
     <MatchRecordLayout

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './selectedPlayer';

--- a/src/stores/selectedPlayer.ts
+++ b/src/stores/selectedPlayer.ts
@@ -1,11 +1,32 @@
 import { create } from 'zustand';
 
-interface SelectedPlayerIdStore {
-  selectedPlayerId: number | null;
-  setSelectedPlayerId: (playerId: number) => void;
+export type TeamType = 'home' | 'away';
+
+export interface SelectedPlayer {
+  teamType: TeamType;
+  id: number;
 }
 
-export const useSelectedPlayerStore = create<SelectedPlayerIdStore>(set => ({
-  selectedPlayerId: null,
-  setSelectedPlayerId: playerId => set({ selectedPlayerId: playerId }),
+type SelectedPlayerStore =
+  | {
+      isSelected: true;
+      selectedPlayer: SelectedPlayer;
+      selectPlayer: (selectedPlayer: SelectedPlayer) => void;
+      unselectPlayer: () => void;
+    }
+  | {
+      isSelected: false;
+      selectedPlayer: undefined;
+      selectPlayer: (selectedPlayer: SelectedPlayer) => void;
+      unselectPlayer: () => void;
+    };
+
+export const useSelectedPlayerStore = create<SelectedPlayerStore>(set => ({
+  isSelected: false,
+  selectedPlayer: undefined,
+  selectPlayer: (selectedPlayer: SelectedPlayer) => {
+    set({ isSelected: true, selectedPlayer });
+    console.log('selected:', selectedPlayer);
+  },
+  unselectPlayer: () => set({ isSelected: false, selectedPlayer: undefined }),
 }));

--- a/src/stores/selectedPlayer.ts
+++ b/src/stores/selectedPlayer.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface SelectedPlayerIdStore {
+  selectedPlayerId: number | null;
+  setSelectedPlayerId: (playerId: number) => void;
+}
+
+export const useSelectedPlayerStore = create<SelectedPlayerIdStore>(set => ({
+  selectedPlayerId: null,
+  setSelectedPlayerId: playerId => set({ selectedPlayerId: playerId }),
+}));


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-138](https://match-day.atlassian.net/browse/MAT-138)
- '선택된 선수 상태'를 전역 상태로 변경하고, Tanstack-Query 도입을 고려한 props 전달 구조 변경

## Changes

- [x] zustand 설치
- [x] stores/selectedPlayer 전역 상태 생성
- [x] 기존 '선택된 선수' 상태에 `null` 값 추가 (미선택 시)
- [x] Store에 대한 결합을 통한 기존 컴포넌트들에 대한 props drilling 제거 (현재 디자인 상 별도의 사용사례 없어서 결정)

### Screenshots

https://github.com/user-attachments/assets/5cad2051-9c6f-4af8-bbd3-95b5954b6230

## Todo

- [ ] 경기 조회 페이지의 HTTP API를 Tanstack-query 기반으로 연동하고, 현재 mock에 의존하는 코드를 해당 상태에 의존하도록 구현