### PR TITLE
fix: [MAT-168, MAT-169] 경기 참여자/팀 조회 Response DTO 변동 대응, 임시 어드민 선택 불가, 즉시 리로드 개선

### DIFF
--- a/src/apis/models/MatchUserCreateRequest.ts
+++ b/src/apis/models/MatchUserCreateRequest.ts
@@ -20,5 +20,5 @@ export interface MatchUserCreateRequest {
   /** 매치에서의 포지션 */
   matchPosition: string;
   /** 매치에서의 그리드 위치 */
-  matchGrid: string;
+  matchGrid: number;
 }

--- a/src/apis/models/MatchUserResponse.ts
+++ b/src/apis/models/MatchUserResponse.ts
@@ -19,7 +19,7 @@ export interface MatchUserResponse {
   /** 매치 포지션 */
   matchPosition: string;
   /** 경기장 그리드 위치 */
-  matchGrid: string;
+  matchGrid: number | null;
   /** 득점 수 */
   goals: number;
   /** 어시스트 수 */
@@ -32,4 +32,6 @@ export interface MatchUserResponse {
   caution: number;
   /** 퇴장 여부 (옐로 2장 이상 또는 레드 1장 이상) */
   sentOff: boolean;
+  /** 프로필 이미지 url */
+  profileImg: string;
 }

--- a/src/apis/models/TeamResponse.ts
+++ b/src/apis/models/TeamResponse.ts
@@ -12,4 +12,5 @@ export interface TeamResponse {
   teamColor: string;
   bottomColor: string;
   stockingColor: string;
+  teamImg: string;
 }

--- a/src/apis/queries/matchRecord.ts
+++ b/src/apis/queries/matchRecord.ts
@@ -5,7 +5,7 @@ const queryKeyNamespaces = {
   matches: 'matches',
 };
 
-const queryKeys = {
+export const queryKeys = {
   matchInfo: (matchId: number) => [queryKeyNamespaces.matches, matchId, 'info'],
   matchScore: (matchId: number) => [
     queryKeyNamespaces.matches,

--- a/src/apis/queries/teams.ts
+++ b/src/apis/queries/teams.ts
@@ -4,7 +4,7 @@ const queryKeyNamespaces = {
   teams: 'teams',
 };
 
-const queryKeys = {
+export const queryKeys = {
   teamById: (teamId: number) => [queryKeyNamespaces.teams, teamId],
   teamList: () => [queryKeyNamespaces.teams, 'list'],
   teamMemberListById: (teamId: number) => [

--- a/src/components/GameScoreArea/GameScoreArea.tsx
+++ b/src/components/GameScoreArea/GameScoreArea.tsx
@@ -1,4 +1,5 @@
 import { MatchScoreResponse, TeamResponse } from '@/apis/models';
+import noProfilePlayerImage from '@/assets/images/noProfilePlayer.png';
 import { createFallbackImageHandler } from '@/utils';
 
 import * as styles from './GameScoreArea.css';
@@ -38,7 +39,7 @@ const TeamArea = ({
     <div className={styles.teamContainer}>
       <div className={styles.logoWrapper({ isHome })}>
         <img
-          src={team.teamImg}
+          src={team.teamImg ?? noProfilePlayerImage}
           alt=''
           className={styles.logo}
           onError={fallbackImageHandler}

--- a/src/components/GameScoreArea/GameScoreArea.tsx
+++ b/src/components/GameScoreArea/GameScoreArea.tsx
@@ -38,8 +38,7 @@ const TeamArea = ({
     <div className={styles.teamContainer}>
       <div className={styles.logoWrapper({ isHome })}>
         <img
-          // src={team.logoImageUrl ?? noProfilePlayerImage}
-          src='https://via.placeholder.com/150'
+          src={team.teamImg}
           alt=''
           className={styles.logo}
           onError={fallbackImageHandler}

--- a/src/components/PlayerList/PlayerList.tsx
+++ b/src/components/PlayerList/PlayerList.tsx
@@ -42,7 +42,7 @@ export const PlayerList = ({ team, players }: PlayerListProps) => {
         <div className={styles.teamInfo}>
           <img
             className={styles.teamLogo}
-            src={team.teamImg}
+            src={team.teamImg ?? noProfilePlayerImage}
             alt=''
             onError={setFallbackImageIfLoadFail}
           />

--- a/src/components/PlayerList/PlayerList.tsx
+++ b/src/components/PlayerList/PlayerList.tsx
@@ -42,8 +42,7 @@ export const PlayerList = ({ team, players }: PlayerListProps) => {
         <div className={styles.teamInfo}>
           <img
             className={styles.teamLogo}
-            // src={team.logoImageUrl}
-            src='https://via.placeholder.com/150'
+            src={team.teamImg}
             alt=''
             onError={setFallbackImageIfLoadFail}
           />

--- a/src/components/PlayerList/PlayerListItem.tsx
+++ b/src/components/PlayerList/PlayerListItem.tsx
@@ -31,8 +31,7 @@ export const PlayerItem = ({
       <div className={styles.infoContainer}>
         <img
           className={styles.profileImage}
-          // src={player.profileImageUrl}
-          src='https://via.placeholder.com/150'
+          src={player.profileImg}
           alt=''
           onError={setFallbackImageIfLoadFail}
         />

--- a/src/components/PlayerList/PlayerListItem.tsx
+++ b/src/components/PlayerList/PlayerListItem.tsx
@@ -31,7 +31,7 @@ export const PlayerItem = ({
       <div className={styles.infoContainer}>
         <img
           className={styles.profileImage}
-          src={player.profileImg}
+          src={player.profileImg ?? noProfilePlayerImage}
           alt=''
           onError={setFallbackImageIfLoadFail}
         />

--- a/src/components/PlayerOnFieldGrid/FieldGridCell/PlayerOnFieldGridCell.tsx
+++ b/src/components/PlayerOnFieldGrid/FieldGridCell/PlayerOnFieldGridCell.tsx
@@ -47,8 +47,7 @@ export const PlayerOnFieldGridCell = ({
       <div className={styles.playerImageContainer}>
         <img
           className={styles.playerImage}
-          // src={player.profileImageUrl}
-          src='https://via.placeholder.com/150'
+          src={player.profileImg}
           alt={player.name}
           onError={fallbackImageHandler}
         />

--- a/src/components/PlayerOnFieldGrid/FieldGridCell/PlayerOnFieldGridCell.tsx
+++ b/src/components/PlayerOnFieldGrid/FieldGridCell/PlayerOnFieldGridCell.tsx
@@ -1,5 +1,6 @@
 import { MatchUserResponse } from '@/apis/models';
 import { SoccerballIcon } from '@/assets/icons';
+import noProfilePlayerImage from '@/assets/images/noProfilePlayer.png';
 import { useIsDragOver } from '@/hooks';
 import { createFallbackImageHandler } from '@/utils/createFallbackImageHandler';
 
@@ -47,8 +48,8 @@ export const PlayerOnFieldGridCell = ({
       <div className={styles.playerImageContainer}>
         <img
           className={styles.playerImage}
-          src={player.profileImg}
-          alt={player.name}
+          src={player.profileImg ?? noProfilePlayerImage}
+          alt=''
           onError={fallbackImageHandler}
         />
         <div className={styles.attackPointContainer}>

--- a/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.tsx
+++ b/src/components/PlayerOnFieldGrid/PlayerOnFieldGrid.tsx
@@ -19,9 +19,8 @@ export const PlayerOnFieldGrid = ({
 }: PlayerOnFieldGridProps) => {
   const { isSelected, selectedPlayer, selectPlayer } = useSelectedPlayerStore();
 
-  // FIXME: matchGrid 수정 전까지 어쩔 수 없음
   const playerGridMap = new Map(
-    players.map(player => [Math.floor(Math.random() * 30), player]),
+    players.map(player => [player.matchGrid, player]),
   );
 
   console.log(players, playerGridMap);

--- a/src/components/PlayerStatCounterGrid/PlayerBlock/PlayerBlock.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerBlock/PlayerBlock.tsx
@@ -26,7 +26,7 @@ export const PlayerBlock = ({
       <div className={styles.leftContainer}>
         <img
           className={styles.profileImage}
-          src={profileImg}
+          src={profileImg ?? noProfilePlayerImage}
           alt=''
           onError={setFallbackImageIfLoadFail}
         />
@@ -36,7 +36,7 @@ export const PlayerBlock = ({
       <div className={styles.rightContainer}>
         <span className={styles.position}>{matchPosition}</span>
         <img
-          src={team.teamImg}
+          src={team.teamImg ?? noProfilePlayerImage}
           alt=''
           className={styles.teamLogo}
           onError={setFallbackImageIfLoadFail}

--- a/src/components/PlayerStatCounterGrid/PlayerBlock/PlayerBlock.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerBlock/PlayerBlock.tsx
@@ -18,17 +18,15 @@ const setFallbackImageIfLoadFail = (
 };
 
 export const PlayerBlock = ({
-  player: { number, name, matchPosition },
+  team,
+  player: { number, name, matchPosition, profileImg },
 }: PlayerBlockProps) => {
-  const logoImageUrl = 'https://via.placeholder.com/150';
-
   return (
     <li className={styles.rootContainer}>
       <div className={styles.leftContainer}>
         <img
           className={styles.profileImage}
-          // src={profileImageUrl}
-          src='https://via.placeholder.com/150'
+          src={profileImg}
           alt=''
           onError={setFallbackImageIfLoadFail}
         />
@@ -38,7 +36,7 @@ export const PlayerBlock = ({
       <div className={styles.rightContainer}>
         <span className={styles.position}>{matchPosition}</span>
         <img
-          src={logoImageUrl}
+          src={team.teamImg}
           alt=''
           className={styles.teamLogo}
           onError={setFallbackImageIfLoadFail}

--- a/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.tsx
+++ b/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.tsx
@@ -30,7 +30,7 @@ export const PlayerListItem = ({ player }: ListItemProps) => {
     >
       <img
         className={styles.profileImage}
-        src='https://via.placeholder.com/150'
+        src={player.profileImg}
         alt=''
         onError={setFallbackImageIfLoadFail}
       />

--- a/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.tsx
+++ b/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.tsx
@@ -30,7 +30,7 @@ export const PlayerListItem = ({ player }: ListItemProps) => {
     >
       <img
         className={styles.profileImage}
-        src={player.profileImg}
+        src={player.profileImg ?? noProfilePlayerImage}
         alt=''
         onError={setFallbackImageIfLoadFail}
       />

--- a/src/mocks/matchRecord.ts
+++ b/src/mocks/matchRecord.ts
@@ -8,7 +8,7 @@ export const mockHomeTeam: TeamResponse = {
   teamColor: lightThemeVars.color.soccer.red,
   bottomColor: lightThemeVars.color.soccer.red,
   stockingColor: lightThemeVars.color.soccer.red,
-  // logoImageUrl: 'https://example.com/logo1.png',
+  teamImg: 'https://example.com/logo1.png',
 };
 
 export const mockAwayTeam: TeamResponse = {
@@ -17,7 +17,7 @@ export const mockAwayTeam: TeamResponse = {
   teamColor: '#003A70',
   bottomColor: '#003A70',
   stockingColor: '#003A70',
-  // logoImageUrl: 'https://example.com/logo2.png',
+  teamImg: 'https://example.com/logo2.png',
 };
 
 export const mockHomePlayer: MatchUserResponse = {
@@ -31,8 +31,9 @@ export const mockHomePlayer: MatchUserResponse = {
   caution: 10,
   yellowCards: 0,
   redCards: 0,
-  matchGrid: '1',
+  matchGrid: 1,
   sentOff: false,
+  profileImg: 'https://example.com/profile1.png',
 };
 
 export const mockAwayPlayer: MatchUserResponse = {
@@ -45,9 +46,10 @@ export const mockAwayPlayer: MatchUserResponse = {
   caution: 10,
   yellowCards: 0,
   redCards: 0,
-  matchGrid: '1',
+  matchGrid: 1,
   sentOff: false,
   matchPosition: 'FW',
+  profileImg: 'https://example.com/profile2.png',
 };
 
 export const mockLogs: MatchEventResponse[] = Array.from(
@@ -125,14 +127,14 @@ export const mockPlayersByTeamType = (
     name: playerNames[startingIdx + 1 + idx],
     number: 99,
     matchPosition: 'FW',
-    profileImageUrl: 'https://via.placeholder.com/150',
+    profileImg: 'https://via.placeholder.com/150',
     goals: Math.max(0, 5 - idx),
     assists: Math.max(0, idx - 5),
     caution: 2,
     yellowCards: idx % 2 === 0 ? 1 : 0,
     redCards: idx % 3 === 0 ? 1 : 0,
     sentOff: false,
-    matchGrid: `${gridPositions[idx]}`, // FIXME: 추후 변경 예정
+    matchGrid: gridPositions[idx], // FIXME: 추후 변경 예정
   }));
 };
 

--- a/src/routes/admin/-components/MatchCreateForm.schema.ts
+++ b/src/routes/admin/-components/MatchCreateForm.schema.ts
@@ -37,7 +37,7 @@ export const createSchema = (teamList: TeamSearchResponse[]): RJSFSchema => ({
       oneOf: teamList.map(team => ({
         type: 'integer',
         title: `${team.name} (id: ${team.id})`,
-        enum: [team.id],
+        const: team.id,
       })),
       default: teamList[0]?.id,
     },
@@ -48,7 +48,7 @@ export const createSchema = (teamList: TeamSearchResponse[]): RJSFSchema => ({
       oneOf: teamList.map(team => ({
         type: 'integer',
         title: `${team.name} (id: ${team.id})`,
-        enum: [team.id],
+        const: team.id,
       })),
       default: teamList[1]?.id,
     },

--- a/src/routes/admin/-components/MatchCreateForm.tsx
+++ b/src/routes/admin/-components/MatchCreateForm.tsx
@@ -4,7 +4,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { MatchCreateRequest } from '@/apis/models/MatchCreateRequest';
 import { useCreateMatchMutation } from '@/apis/mutations';
-import { teamQuery } from '@/apis/queries';
+import { matchRecordQuery, teamQuery } from '@/apis/queries';
+import { queryClient } from '@/react-query-provider';
 
 import * as styles from './MatchCreateForm.css';
 import { createSchema, uiSchema } from './MatchCreateForm.schema';
@@ -17,6 +18,13 @@ export const MatchCreateForm = () => {
 
   const onSubmit = async (data: MatchCreateRequest) => {
     await createMatch(data);
+    // NOTE: 모든 팀의 모든 매치 목록을 갱신할 필요는 없음 -> 한 번에 하는 방법 = ?
+    queryClient.invalidateQueries({
+      queryKey: matchRecordQuery.queryKeys.matchList(data.homeTeamId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: matchRecordQuery.queryKeys.matchList(data.awayTeamId),
+    });
   };
 
   return (

--- a/src/routes/admin/-components/UserCreateAndJoinForm.schema.ts
+++ b/src/routes/admin/-components/UserCreateAndJoinForm.schema.ts
@@ -38,7 +38,7 @@ export const createSchema = (teamList: TeamSearchResponse[]): RJSFSchema => ({
       oneOf: teamList.map(team => ({
         type: 'integer',
         title: `${team.name} (id: ${team.id})`,
-        enum: [team.id],
+        const: team.id,
       })),
       default: teamList[0]?.id,
     },

--- a/src/routes/admin/-components/UserCreateAndJoinForm.tsx
+++ b/src/routes/admin/-components/UserCreateAndJoinForm.tsx
@@ -7,6 +7,7 @@ import {
   useUserJoinTeamMutation,
 } from '@/apis/mutations';
 import { teamQuery } from '@/apis/queries';
+import { queryClient } from '@/react-query-provider';
 
 import * as styles from './UserCreateAndJoinForm.css';
 import { createSchema, uiSchema } from './UserCreateAndJoinForm.schema';
@@ -33,6 +34,9 @@ export const UserCreateAndJoinForm = () => {
   }) => {
     const userId = (await createUser(name)).data;
     await userJoinTeam({ userId, teamId, number, defaultPosition });
+    queryClient.invalidateQueries({
+      queryKey: teamQuery.queryKeys.teamMemberListById(teamId),
+    });
   };
 
   return (

--- a/src/routes/admin/-components/UserMatchJoinForm.schema.ts
+++ b/src/routes/admin/-components/UserMatchJoinForm.schema.ts
@@ -93,9 +93,11 @@ export const createSchema = (
       enum: ['FW', 'MF', 'DF', 'GK'],
     },
     matchGrid: {
-      type: 'string',
+      type: 'number',
       title: '선발 선수 위치',
-      default: 'A1', // FIXME: 규칙 알 수 없음
+      default: 0,
+      minimum: 0,
+      maximum: 29,
     },
   },
 });

--- a/src/routes/admin/-components/UserMatchJoinForm.tsx
+++ b/src/routes/admin/-components/UserMatchJoinForm.tsx
@@ -10,7 +10,8 @@ import {
   TeamSearchResponse,
 } from '@/apis/models';
 import { useCreateMatchUserMutation } from '@/apis/mutations';
-import { teamQuery } from '@/apis/queries';
+import { matchRecordQuery, teamQuery } from '@/apis/queries';
+import { queryClient } from '@/react-query-provider';
 
 import * as styles from './UserMatchJoinForm.css';
 import { createSchema, uiSchema } from './UserMatchJoinForm.schema';
@@ -72,6 +73,9 @@ export const UserMatchJoinForm = ({
       matchPosition,
       matchGrid,
       role,
+    });
+    queryClient.invalidateQueries({
+      queryKey: matchRecordQuery.queryKeys.matchPlayers(matchId),
     });
   };
 

--- a/src/routes/admin/-components/UserMatchJoinForm.tsx
+++ b/src/routes/admin/-components/UserMatchJoinForm.tsx
@@ -22,7 +22,7 @@ interface FormData {
   userId: number;
   teamId: number;
   matchPosition: string;
-  matchGrid: string;
+  matchGrid: number;
   role: MatchUserCreateRequestRole;
 }
 
@@ -46,7 +46,7 @@ export const UserMatchJoinForm = ({
     userId: -1,
     teamId: -1,
     matchPosition: 'FW',
-    matchGrid: '1',
+    matchGrid: 0,
     role: 'START_PLAYER',
   });
   const { data: teamMemberList } = useQuery({


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-168](https://match-day.atlassian.net/browse/MAT-168) 경기 참여자/팀 조회 Server Response 개선 사항 대응 (프로필 사진, matchGrid 타입)
- [Jira Ticket: MAT-169](https://match-day.atlassian.net/browse/MAT-169) 임시 어드민 - 일부 폼에서 팀 선택 불가 오류 수정 및 즉시 리로딩하도록 개선

## Changes

- [x] TeamResponse, MatchUserResponse, MatchUserCreateRequest 모델 변경 사항 반영 (matchGrid, profileImg)
- [x] 선수/팀 프로필 이미지 nullable 대응(기본 이미지 표시) 추가
- [x] 임시 어드민 - 팀 선택 불가 수정(`enum` -> `const`), 리로드 개선(`invalidateQueries`)
