### PR TITLE
fix: [MAT-182,MAT-183,MAT-184] 퍼블리싱 반영 및 개선: 팀 스텟 그리드, 교체 선수 리스트, 경기 로그 리스트

### DIFF
--- a/src/apis/models/MatchEventResponse.ts
+++ b/src/apis/models/MatchEventResponse.ts
@@ -5,6 +5,7 @@
  * MatchDay 요구사항에 대한 REST API
  * OpenAPI spec version: 0.0.1
  */
+import { MatchEventType } from '@/constants';
 
 /**
  * 경기 이벤트 응답 DTO
@@ -23,5 +24,5 @@ export interface MatchEventResponse {
   /** 선수 이름 */
   userName: string;
   /** 이벤트 로그 */
-  eventLog: string;
+  eventLog: MatchEventType; // NOTE: 임의로 매핑
 }

--- a/src/apis/models/ScoreResponse.ts
+++ b/src/apis/models/ScoreResponse.ts
@@ -24,4 +24,6 @@ export interface ScoreResponse {
   foulCount: number;
   /** 경고 횟수 */
   warningCount: number;
+  /** 자책골 횟수 */
+  ownGoalCount: number; // FIXME: 서버에서 추가 필요
 }

--- a/src/components/GameScoreArea/GameScoreArea.stories.tsx
+++ b/src/components/GameScoreArea/GameScoreArea.stories.tsx
@@ -47,6 +47,7 @@ export const Default: Story = {
         offsideCount: 0,
         foulCount: 0,
         warningCount: 0,
+        ownGoalCount: 0,
       },
       awayScore: {
         goalCount: 19,
@@ -56,6 +57,7 @@ export const Default: Story = {
         offsideCount: 0,
         foulCount: 0,
         warningCount: 0,
+        ownGoalCount: 0,
       },
       homeTeamId: 1,
       awayTeamId: 2,

--- a/src/components/MatchLogList/MatchLogList.stories.css.ts
+++ b/src/components/MatchLogList/MatchLogList.stories.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
 
 export const rootContainer = style({
-  width: 300,
+  width: 280,
 });

--- a/src/components/MatchLogList/MatchLogListItem/MatchLogListItem.css.ts
+++ b/src/components/MatchLogList/MatchLogListItem/MatchLogListItem.css.ts
@@ -13,7 +13,7 @@ export const rootContainer = recipe({
     flexShrink: 0,
     alignItems: 'center',
 
-    gap: 20,
+    gap: 12,
     borderBottom: `1px solid ${lightThemeVars.color.primary[100]}`,
     padding: '0 20px',
     height: 36,
@@ -41,7 +41,7 @@ export const rootContainer = recipe({
 });
 
 // NOTE: 중복 제거 필요해보임 (Typography)
-export const commonText = style({
+const commonText = style({
   lineHeight: 1.4,
   letterSpacing: -0.35,
   fontSize: 14,
@@ -49,7 +49,7 @@ export const commonText = style({
   fontStyle: 'normal',
 });
 
-export const commonLineClamp = style({
+const commonLineClamp = style({
   display: '-webkit-box',
   overflow: 'hidden',
   WebkitLineClamp: 1,
@@ -59,10 +59,30 @@ export const commonLineClamp = style({
 export const teamName = style([
   commonText,
   commonLineClamp,
-  // NOTE: 우선 임의로 길이를 지정해서 ... 처리 추가함
   {
     width: 50,
   },
 ]);
 
-export const text = style([commonText]);
+export const time = style([
+  commonText,
+  {
+    width: 30,
+  },
+]);
+
+export const name = style([
+  commonText,
+  {
+    width: 50,
+    textAlign: 'center',
+  },
+]);
+
+export const event = style([
+  commonText,
+  commonLineClamp,
+  {
+    flex: 1,
+  },
+]);

--- a/src/components/MatchLogList/MatchLogListItem/MatchLogListItem.tsx
+++ b/src/components/MatchLogList/MatchLogListItem/MatchLogListItem.tsx
@@ -17,10 +17,10 @@ export const MatchLogListItem = ({ teams, log }: MatchLogListItemProps) => {
         team: log.teamId === teams.home.id ? 'home' : 'away',
       })}
     >
-      <span className={styles.text}>{log.elapsedMinutes}&quot;</span>
+      <span className={styles.time}>{log.elapsedMinutes}&quot;</span>
       <span className={styles.teamName}>{log.teamName}</span>
-      <span className={styles.text}>{log.userName}</span>
-      <span className={styles.text}>{log.eventLog}</span>
+      <span className={styles.name}>{log.userName}</span>
+      <span className={styles.event}>{log.eventLog}</span>
     </li>
   );
 };

--- a/src/components/MatchLogList/MatchLogListItem/MatchLogListItem.tsx
+++ b/src/components/MatchLogList/MatchLogListItem/MatchLogListItem.tsx
@@ -1,4 +1,5 @@
 import { MatchEventResponse, TeamResponse } from '@/apis/models';
+import { MatchEventNameMap } from '@/constants';
 
 import * as styles from './MatchLogListItem.css';
 
@@ -20,7 +21,7 @@ export const MatchLogListItem = ({ teams, log }: MatchLogListItemProps) => {
       <span className={styles.time}>{log.elapsedMinutes}&quot;</span>
       <span className={styles.teamName}>{log.teamName}</span>
       <span className={styles.name}>{log.userName}</span>
-      <span className={styles.event}>{log.eventLog}</span>
+      <span className={styles.event}>{MatchEventNameMap[log.eventLog]}</span>
     </li>
   );
 };

--- a/src/components/StatCounterItem/StatCounterItem.css.ts
+++ b/src/components/StatCounterItem/StatCounterItem.css.ts
@@ -6,14 +6,25 @@ import { lightThemeVars } from '@/styles/theme.css';
 
 export const rootContainer = recipe({
   base: {
+    boxSizing: 'border-box',
     display: 'flex',
-    flexDirection: 'column',
-    flexGrow: 1, // NOTE: flex 부모일 때는 부모가 설정한 영역 사용
+    flexDirection: 'column', // NOTE: flex 부모일 때는 부모가 설정한 영역 사용
+    flexGrow: 1,
     alignItems: 'center',
-    gap: 10,
-    border: `1px solid ${lightThemeVars.color.primary['100']}`,
-    borderRadius: 6,
-    padding: 9,
+    gap: 5,
+    borderRight: `1px solid ${lightThemeVars.color.primary['100']}`,
+    padding: '12px 7px',
+    height: 73,
+
+    selectors: {
+      '&:nth-child(n+5)': {
+        borderTop: `1px solid ${lightThemeVars.color.primary['100']}`,
+      },
+      // NOTE: 2*4 그리드 기준이므로 그리드 구성 변경 시마다 반영 필요
+      '&:nth-child(4n)': {
+        borderRight: 'none',
+      },
+    },
   },
   variants: {
     disabled: {
@@ -43,14 +54,14 @@ export const title = recipe({
 
 export const value = recipe({
   base: {
-    width: 35,
+    width: 25,
     textAlign: 'center',
-    lineHeight: '1',
-    letterSpacing: -0.35,
+    lineHeight: 1,
+    letterSpacing: -0.5,
     color: lightThemeVars.color.gray[600],
 
-    fontSize: 32,
-    fontWeight: 500,
+    fontSize: 20,
+    fontWeight: 600,
   },
   variants: {
     colorIntegration: {
@@ -78,8 +89,8 @@ export const button = style({
   border: `1px solid ${lightThemeVars.color.primary['300']}`,
   borderRadius: '50%',
   cursor: 'pointer',
-  width: 24,
-  height: 24,
+  width: 20,
+  height: 20,
   color: lightThemeVars.color.gray['600'],
 
   ':hover': {

--- a/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.css.ts
+++ b/src/components/SubstitutionPlayerList/PlayerListItem/PlayerListItem.css.ts
@@ -7,9 +7,10 @@ export const rootContainer = recipe({
   base: {
     display: 'flex',
     alignItems: 'center',
-    gap: 14,
     transition: 'background-color 0.3s ease',
-    padding: '6px 24px',
+    paddingTop: 6,
+    paddingBottom: 6,
+    paddingLeft: 24,
     userSelect: 'none', // NOTE: 드래그 할 때 텍스트 선택되는 문제를 방지하기 위함
 
     ':hover': {
@@ -21,15 +22,21 @@ export const rootContainer = recipe({
       true: {
         cursor: 'not-allowed',
       },
+      false: {
+        cursor: 'grab',
+      },
     },
+  },
+  defaultVariants: {
+    disabled: false,
   },
 });
 
 export const profileImage = style({
-  borderRadius: 100,
+  borderRadius: '50%',
   objectFit: 'cover',
-  width: 32,
-  height: 32,
+  width: 28,
+  height: 28,
 });
 
 const commonTextStyle = {
@@ -43,11 +50,12 @@ export const textContainer = recipe({
   base: [
     commonTextStyle,
     {
+      marginLeft: 10,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between',
       width: 136,
-      height: 44,
+      height: 20,
     },
   ],
   variants: {
@@ -74,6 +82,7 @@ export const statContainer = recipe({
     display: 'flex',
     justifyContent: 'space-between',
     gap: 16,
+    marginLeft: 33,
   },
   variants: {
     disabled: {

--- a/src/components/SubstitutionPlayerList/SubstitutionPlayerList.css.ts
+++ b/src/components/SubstitutionPlayerList/SubstitutionPlayerList.css.ts
@@ -1,14 +1,10 @@
 import { style } from '@vanilla-extract/css';
 
-import { lightThemeVars } from '@/styles/theme.css';
-
 export const rootContainer = style({
   boxSizing: 'border-box',
   display: 'flex',
   flexDirection: 'column',
-  border: `1px solid ${lightThemeVars.color.primary['100']}`,
-  borderRadius: 10,
-  height: 186,
+  height: 264,
 });
 
 export const header = style({
@@ -28,7 +24,15 @@ export const title = style({
 
 export const list = style({
   display: 'flex',
+  flex: 1,
   flexDirection: 'column',
-  height: 144,
   overflowY: 'auto',
+
+  // FIXME: 디자인과 일치하지는 않는데 - 우선 진행
+  maskImage: `linear-gradient(
+    to bottom,
+    #fff 30%,
+    rgba(255,255,255,0.70) 75%,
+    rgba(255,255,255,0.3) 100%
+  )`,
 });

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.stories.tsx
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.stories.tsx
@@ -47,6 +47,7 @@ export const Default: Story = {
       foulCount: 10,
       warningCount: 3,
       shotCount: 12,
+      ownGoalCount: 0,
     },
     awayTeamStat: {
       goalCount: 8,
@@ -56,6 +57,7 @@ export const Default: Story = {
       foulCount: 14,
       warningCount: 2,
       shotCount: 8,
+      ownGoalCount: 0,
     },
   },
 };
@@ -71,6 +73,7 @@ export const Empty: Story = {
       foulCount: 0,
       warningCount: 0,
       shotCount: 0,
+      ownGoalCount: 0,
     },
     awayTeamStat: {
       goalCount: 0,
@@ -80,6 +83,7 @@ export const Empty: Story = {
       foulCount: 0,
       warningCount: 0,
       shotCount: 0,
+      ownGoalCount: 0,
     },
   },
 };
@@ -95,6 +99,7 @@ export const Max20: Story = {
       foulCount: 12,
       warningCount: 2,
       shotCount: 10,
+      ownGoalCount: 0,
     },
     awayTeamStat: {
       goalCount: 10,
@@ -104,6 +109,7 @@ export const Max20: Story = {
       foulCount: 12,
       warningCount: 2,
       shotCount: 10,
+      ownGoalCount: 0,
     },
   },
 };

--- a/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.tsx
+++ b/src/components/TeamStatCompareCounterList/TeamStatCompareCounterList.tsx
@@ -1,6 +1,6 @@
 import { ScoreResponse } from '@/apis/models';
 import { StatCompareCounter } from '@/components';
-import { STAT_LIST, statMapper } from '@/constants';
+import { STAT_LIST_FOR_COMPARE, statMapper } from '@/constants';
 
 import * as styles from './TeamStatCompareCounterList.css';
 
@@ -17,7 +17,7 @@ export const TeamStatCompareCounterList = ({
 }: TeamStatCompareCounterListProps) => {
   return (
     <div className={styles.container}>
-      {STAT_LIST.map(stat => (
+      {STAT_LIST_FOR_COMPARE.map(stat => (
         <StatCompareCounter
           key={stat}
           label={stat}

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.css.ts
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.css.ts
@@ -1,8 +1,17 @@
 import { style } from '@vanilla-extract/css';
 
+import { lightThemeVars } from '@/styles/theme.css';
+
 export const rootContainer = style({
-  display: 'grid',
-  gridTemplateRows: 'repeat(2, 80px)',
-  gridTemplateColumns: 'repeat(3, 110px)',
-  gap: 4,
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+// NOTE: grid로 4*2 구성하고 싶었지만, 컨테이너 padding에도 border를 적용해야 하므로 flex로 렌더링
+export const gridLine = style({
+  display: 'flex',
+  flexDirection: 'row',
+  borderTop: `1px solid ${lightThemeVars.color.primary['100']}`,
+  paddingRight: 3,
+  paddingLeft: 3,
 });

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.stories.tsx
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.stories.tsx
@@ -40,6 +40,7 @@ export const Default: Story = {
       offsideCount: 0,
       foulCount: 24,
       warningCount: 10,
+      ownGoalCount: 0,
     },
   },
 };
@@ -54,6 +55,7 @@ export const Empty: Story = {
       offsideCount: 0,
       foulCount: 0,
       warningCount: 0,
+      ownGoalCount: 0,
     },
   },
 };

--- a/src/components/TeamStatCounterGrid/TeamStatCounterGrid.tsx
+++ b/src/components/TeamStatCounterGrid/TeamStatCounterGrid.tsx
@@ -25,18 +25,35 @@ export const TeamStatCounterGrid = ({
     }
   };
 
+  const firstLine = STAT_LIST.slice(0, 4);
+  const secondLine = STAT_LIST.slice(4, 8);
+
+  // NOTE: grid로 4*2 구성하고 싶었지만, 컨테이너 padding에도 border를 적용해야 하므로 flex로 렌더링
   return (
     <div className={styles.rootContainer}>
-      {STAT_LIST.map(stat => (
-        <StatCounterItem
-          key={stat}
-          title={stat}
-          value={stats[statMapper[stat]]}
-          // FIXME: keyof 타입 캐스팅 없이도 가능하게?
-          onIncrement={() => handleIncrement(stat as keyof ScoreResponse)}
-          onDecrement={() => handleDecrement(stat as keyof ScoreResponse)}
-        />
-      ))}
+      <div className={styles.gridLine}>
+        {firstLine.map(stat => (
+          <StatCounterItem
+            key={stat}
+            title={stat}
+            value={stats[statMapper[stat]]}
+            // FIXME: keyof 타입 캐스팅 없이도 가능하게?
+            onIncrement={() => handleIncrement(stat as keyof ScoreResponse)}
+            onDecrement={() => handleDecrement(stat as keyof ScoreResponse)}
+          />
+        ))}
+      </div>
+      <div className={styles.gridLine}>
+        {secondLine.map(stat => (
+          <StatCounterItem
+            key={stat}
+            title={stat}
+            value={stats[statMapper[stat]]}
+            onIncrement={() => handleIncrement(stat as keyof ScoreResponse)}
+            onDecrement={() => handleDecrement(stat as keyof ScoreResponse)}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.css.ts
+++ b/src/components/ToggleableStartingPlayers/ToggleableStartingPlayers.css.ts
@@ -1,16 +1,20 @@
 import { style } from '@vanilla-extract/css';
 
+import { commonPaper } from '@/styles/paper.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
-export const rootContainer = style({
-  position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-end',
-  gap: 5,
-  width: '100%',
-  height: 462,
-});
+export const rootContainer = style([
+  commonPaper,
+  {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    gap: 5,
+    width: '100%',
+    height: 462,
+  },
+]);
 
 export const toggleButton = style({
   position: 'absolute',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './query';
 export * from './stats';
+export * from './matchEvents';

--- a/src/constants/matchEvents.ts
+++ b/src/constants/matchEvents.ts
@@ -1,0 +1,26 @@
+export type MatchEventType =
+  | 'GOAL'
+  | 'ASSIST'
+  | 'SHOT'
+  | 'VALID_SHOT'
+  | 'FOUL'
+  | 'OFFSIDE'
+  | 'SUB_IN'
+  | 'SUB_OUT'
+  | 'YELLOW_CARD'
+  | 'RED_CARD'
+  | 'OWN_GOAL';
+
+export const MatchEventNameMap: Record<MatchEventType, string> = {
+  GOAL: '득점',
+  ASSIST: '어시스트',
+  SHOT: '슈팅',
+  VALID_SHOT: '유효 슈팅',
+  FOUL: '파울',
+  OFFSIDE: '오프 사이드',
+  SUB_IN: '교체 출전',
+  SUB_OUT: '교체 퇴장',
+  YELLOW_CARD: '옐로 카드',
+  RED_CARD: '레드 카드',
+  OWN_GOAL: '자책골',
+};

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,6 +1,6 @@
 import { ScoreResponse } from '@/apis/models';
 
-type Stat =
+export type Stat =
   | '득점'
   | '슈팅'
   | '유효 슈팅'

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -21,6 +21,15 @@ export const STAT_LIST: Stat[] = [
   '자책골',
 ];
 
+export const STAT_LIST_FOR_COMPARE: Stat[] = [
+  '슈팅',
+  '유효 슈팅',
+  '코너 킥',
+  '오프 사이드',
+  '파울',
+  '경고',
+];
+
 export const statMapper: Record<Stat, keyof ScoreResponse> = {
   득점: 'goalCount',
   슈팅: 'goalCount',

--- a/src/constants/stats.ts
+++ b/src/constants/stats.ts
@@ -1,21 +1,33 @@
 import { ScoreResponse } from '@/apis/models';
 
-type Stat = '슈팅' | '유효 슈팅' | '코너 킥' | '오프 사이드' | '파울' | '경고';
+type Stat =
+  | '득점'
+  | '슈팅'
+  | '유효 슈팅'
+  | '코너 킥'
+  | '오프 사이드'
+  | '파울'
+  | '경고'
+  | '자책골';
 
 export const STAT_LIST: Stat[] = [
+  '득점',
   '슈팅',
   '유효 슈팅',
   '코너 킥',
   '오프 사이드',
   '파울',
   '경고',
+  '자책골',
 ];
 
 export const statMapper: Record<Stat, keyof ScoreResponse> = {
+  득점: 'goalCount',
   슈팅: 'goalCount',
   '유효 슈팅': 'validShotCount',
   '코너 킥': 'cornerKickCount',
   '오프 사이드': 'offsideCount',
   파울: 'foulCount',
   경고: 'warningCount',
+  자책골: 'ownGoalCount',
 };

--- a/src/mocks/matchRecord.ts
+++ b/src/mocks/matchRecord.ts
@@ -44,8 +44,8 @@ export const mockAwayTeam: TeamResponse = {
 
 export const mockHomePlayer: MatchUserResponse = {
   id: 1,
-  name: '홍길동',
-  number: 10,
+  name: '호나우두',
+  number: 99,
   matchPosition: 'FW',
   // profileImageUrl: 'https://example.com/profile1.png',
   goals: 10,
@@ -102,7 +102,7 @@ export const mockLogs: MatchEventResponse[] = Array.from(
       teamName: mockHomeTeam.name,
       userId: mockHomePlayer.id,
       userName: mockHomePlayer.name,
-      elapsedMinutes: 10,
+      elapsedMinutes: 9999,
     },
   ],
 ).flat();

--- a/src/mocks/matchRecord.ts
+++ b/src/mocks/matchRecord.ts
@@ -4,6 +4,7 @@ import {
   MatchUserResponse,
 } from '@/apis/models';
 import { TeamResponse } from '@/apis/models';
+import { MatchEventType } from '@/constants';
 import { lightThemeVars } from '@/styles/theme.css';
 
 export const mockMatchInfo: MatchInfoResponse = {
@@ -79,7 +80,7 @@ export const mockLogs: MatchEventResponse[] = Array.from(
   (_, index) => [
     {
       id: index * 3 + 1,
-      eventLog: '유효 슈팅',
+      eventLog: 'VALID_SHOT' as MatchEventType,
       teamId: mockHomeTeam.id,
       teamName: mockHomeTeam.name,
       userId: mockHomePlayer.id,
@@ -88,7 +89,7 @@ export const mockLogs: MatchEventResponse[] = Array.from(
     },
     {
       id: index * 3 + 2,
-      eventLog: '골',
+      eventLog: 'GOAL' as MatchEventType,
       teamId: mockAwayTeam.id,
       teamName: mockAwayTeam.name,
       userId: mockAwayPlayer.id,
@@ -97,7 +98,7 @@ export const mockLogs: MatchEventResponse[] = Array.from(
     },
     {
       id: index * 3 + 3,
-      eventLog: '골',
+      eventLog: 'GOAL' as MatchEventType,
       teamId: mockHomeTeam.id,
       teamName: mockHomeTeam.name,
       userId: mockHomePlayer.id,

--- a/src/routes/matches/$matchId/record/route.tsx
+++ b/src/routes/matches/$matchId/record/route.tsx
@@ -142,7 +142,6 @@ function MatchRecordPage() {
           />
           <div
             style={{
-              padding: '24px 8px',
               display: 'flex',
               flexDirection: 'column',
               gap: 20,
@@ -171,7 +170,6 @@ function MatchRecordPage() {
           />
           <div
             style={{
-              padding: '24px 8px',
               display: 'flex',
               flexDirection: 'column',
               gap: 20,

--- a/src/routes/matches/$matchId/record/route.tsx
+++ b/src/routes/matches/$matchId/record/route.tsx
@@ -134,6 +134,7 @@ function MatchRecordPage() {
             ...s('auto'),
             display: 'flex',
             flexDirection: 'column',
+            gap: 8,
           }}
         >
           <ToggleableStartingPlayers
@@ -144,7 +145,6 @@ function MatchRecordPage() {
             style={{
               display: 'flex',
               flexDirection: 'column',
-              gap: 20,
             }}
           >
             <SubstitutionPlayerList
@@ -162,6 +162,7 @@ function MatchRecordPage() {
             ...s('auto'),
             display: 'flex',
             flexDirection: 'column',
+            gap: 8,
           }}
         >
           <ToggleableStartingPlayers
@@ -172,7 +173,6 @@ function MatchRecordPage() {
             style={{
               display: 'flex',
               flexDirection: 'column',
-              gap: 20,
             }}
           >
             <SubstitutionPlayerList


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-182](https://match-day.atlassian.net/browse/MAT-182) 신규 팀 스텟 그리드 디자인 변경 사항 반영
- [Jira Ticket: MAT-183](https://match-day.atlassian.net/browse/MAT-183) 신규 교체 선수 리스트 디자인 변경 사항 반영
- [Jira Ticket: MAT-184](https://match-day.atlassian.net/browse/MAT-184) 경기 로그 화면 퍼블리싱 개선

## Changes

- [x] 기획 변경으로 인해 팀 스텟 가짓수를 8종으로 변경 (득점, 자책골 필드 추가)
- [x] 팀 스텟 그리드 디자인 변경
- [x] 선수 교체 리스트 디자인 변경
- [x] 경기 로그 리스트 깨짐 개선 (퍼블리싱, raw 값 표기 문제)

### Screenshots

- [스토리북 참고](https://680b08a7575f04471f05ad14-xjeylufdcu.chromatic.com/)
