### PR TITLE
feat: MAT-211 경기 기록 페이지의 로그 자동으로 하단 스크롤되게 추가

### DIFF
--- a/src/components/MatchLogList/MatchLogList.tsx
+++ b/src/components/MatchLogList/MatchLogList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 import { MatchEventResponse, TeamResponse } from '@/apis/models';
@@ -5,8 +7,7 @@ import { MatchEventResponse, TeamResponse } from '@/apis/models';
 import { EmptyList } from './EmptyList/EmptyList';
 import * as styles from './MatchLogList.css';
 import { MatchLogListItem } from './MatchLogListItem/MatchLogListItem';
-import { teamAwayColor } from './colors.css';
-import { teamHomeColor } from './colors.css';
+import { teamAwayColor, teamHomeColor } from './colors.css';
 
 interface MatchLogListProps {
   teams: {
@@ -17,6 +18,15 @@ interface MatchLogListProps {
 }
 
 export const MatchLogList = ({ teams, logs }: MatchLogListProps) => {
+  const listElemRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    listElemRef.current?.scrollTo({
+      top: listElemRef.current?.scrollHeight ?? 0,
+      behavior: 'smooth',
+    });
+  }, [logs]);
+
   return (
     <div
       className={styles.rootContainer}
@@ -28,7 +38,7 @@ export const MatchLogList = ({ teams, logs }: MatchLogListProps) => {
       <div className={styles.header}>
         <div className={styles.title}>경기 로그</div>
       </div>
-      <ul className={styles.logListContainer}>
+      <ul className={styles.logListContainer} ref={listElemRef}>
         {logs.length === 0 ? (
           // FIXME: 디자인이 없어서 임시로 작업
           <EmptyList />


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-211](https://match-day.atlassian.net/browse/MAT-211)
- 경기 기록 페이지의 로그 자동으로 하단 스크롤되게 추가

## Changes

- [x] 경기 로그 리스트 컴포넌트

### Screenshots

https://github.com/user-attachments/assets/fe726447-7b0e-4aa0-ba56-c30c9c9adaa8


