### PR TITLE
feat: MAT-260 게스트 유저의 소속팀 설정 모달 추가

### DIFF
--- a/src/apis/queries/users.ts
+++ b/src/apis/queries/users.ts
@@ -15,7 +15,14 @@ export const me = queryOptions({
   queryFn: () =>
     delay(500).then(() => {
       if (useLoggedInUserStore.getState().isLoggedIn) {
-        return tempUser;
+        try {
+          // 직접 수정한 경우 localstorage에 임시 백업함
+          return JSON.parse(
+            localStorage.getItem('user') ?? '',
+          ) as typeof tempUser;
+        } catch {
+          return tempUser;
+        }
       }
       return null;
     }),

--- a/src/components/Sidebar/FooterItem/FooterItemList.css.ts
+++ b/src/components/Sidebar/FooterItem/FooterItemList.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import {
   footer,
@@ -10,27 +11,38 @@ import { lightThemeVars } from '@/styles/theme.css';
 
 export { footer, footerItemIcon, label, transitionTiming };
 
-export const footerItem = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  transition: `background-color 0.3s ${transitionTiming}`,
-  cursor: 'not-allowed', // FIXME: 구현 완료 후 다시 변경
-  width: '100%',
-  height: 44,
-  overflow: 'hidden',
-  textDecoration: 'none',
-  whiteSpace: 'nowrap',
-  color: lightThemeVars.color.gray[500],
-  fontSize: 14,
-  selectors: {
-    '&:hover': {
-      backgroundColor: lightThemeVars.color.white.hover,
+export const footerItem = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    transition: `background-color 0.3s ${transitionTiming}`,
+    width: '100%',
+    height: 44,
+    overflow: 'hidden',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+    color: lightThemeVars.color.gray[500],
+    fontSize: 14,
+    selectors: {
+      '&:hover': {
+        backgroundColor: lightThemeVars.color.white.hover,
+      },
+      '&:focus-visible': {
+        outline: 'none',
+        boxShadow: `0 0 0 2px ${lightThemeVars.color.primary[300]}`,
+        backgroundColor: lightThemeVars.color.white.hover,
+      },
     },
-    '&:focus-visible': {
-      outline: 'none',
-      boxShadow: `0 0 0 2px ${lightThemeVars.color.primary[300]}`,
-      backgroundColor: lightThemeVars.color.white.hover,
+  },
+  variants: {
+    disabled: {
+      true: {
+        cursor: 'not-allowed',
+      },
+      false: {
+        cursor: 'pointer',
+      },
     },
   },
 });

--- a/src/components/Sidebar/FooterItem/FooterItemList.tsx
+++ b/src/components/Sidebar/FooterItem/FooterItemList.tsx
@@ -12,6 +12,8 @@ interface FooterItemProps {
   label?: string;
   showArrow?: boolean;
   isOpen: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
 }
 
 export function FooterItem({
@@ -20,9 +22,11 @@ export function FooterItem({
   label,
   showArrow,
   isOpen,
+  disabled,
+  onClick,
 }: FooterItemProps) {
   return (
-    <Link to={to} className={styles.footerItem}>
+    <Link to={to} className={styles.footerItem({ disabled })} onClick={onClick}>
       <div className={styles.footerItemIcon({ isOpen })}>
         {icon}
         {label && <span className={styles.label}>{label}</span>}
@@ -37,6 +41,8 @@ interface FooterItemListProps {
     to: string;
     icon: ReactNode;
     label?: string;
+    disabled?: boolean;
+    onClick?: () => void;
   }>;
   isOpen: boolean;
 }
@@ -52,6 +58,8 @@ export function FooterItemList({ items, isOpen }: FooterItemListProps) {
           label={isOpen ? item.label : undefined}
           showArrow={isOpen}
           isOpen={isOpen}
+          disabled={item.disabled}
+          onClick={item.onClick}
         />
       ))}
     </>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   SettingsIcon,
   UserIcon,
 } from '@/assets/icons';
-import { UserSettingsDialog } from '@/components/UserSettingsDialog';
 import { useUserSettingsModalStore } from '@/stores';
 
 import { FooterItemList } from './FooterItem';
@@ -111,8 +110,6 @@ export function Sidebar({ isOpen, toggle }: SidebarProps) {
         </div>
         {isOpen && <LogoTextIcon className={styles.logoTextImage} />}
       </div>
-
-      <UserSettingsDialog />
     </aside>
   );
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -12,6 +12,8 @@ import {
   SettingsIcon,
   UserIcon,
 } from '@/assets/icons';
+import { UserSettingsDialog } from '@/components/UserSettingsDialog';
+import { useUserSettingsModalStore } from '@/stores';
 
 import { FooterItemList } from './FooterItem';
 import { NavItemList } from './NavItem';
@@ -23,6 +25,8 @@ interface SidebarProps {
 }
 
 export function Sidebar({ isOpen, toggle }: SidebarProps) {
+  const { open } = useUserSettingsModalStore();
+
   const navItems = [
     {
       to: '/',
@@ -57,11 +61,14 @@ export function Sidebar({ isOpen, toggle }: SidebarProps) {
         to: '.',
         icon: <HelpCircleIcon className={styles.icon} />,
         label: '도움말',
+        disabled: true,
       },
       {
         to: '.',
         icon: <SettingsIcon className={styles.icon} />,
         label: '설정',
+        disabled: false,
+        onClick: open,
       },
     ],
     [],
@@ -104,6 +111,8 @@ export function Sidebar({ isOpen, toggle }: SidebarProps) {
         </div>
         {isOpen && <LogoTextIcon className={styles.logoTextImage} />}
       </div>
+
+      <UserSettingsDialog />
     </aside>
   );
 }

--- a/src/components/UserSettingsDialog/UserSettingsDialog.css.ts
+++ b/src/components/UserSettingsDialog/UserSettingsDialog.css.ts
@@ -1,0 +1,59 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { commonPaper } from '@/styles/paper.css';
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const dialog = style([
+  commonPaper,
+  {
+    border: 'none',
+    borderRadius: 10,
+  },
+]);
+
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  gap: 8,
+  padding: 16,
+  width: 320,
+  height: 320,
+});
+
+export const footerContainer = style({
+  display: 'flex',
+  justifyContent: 'space-evenly',
+  gap: 8,
+});
+
+export const button = recipe({
+  base: {
+    flex: 1,
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    padding: 16,
+    fontSize: 16,
+  },
+  variants: {
+    variant: {
+      primary: {
+        backgroundColor: lightThemeVars.color.primary['700'],
+        color: lightThemeVars.color.white.main,
+        ':hover': {
+          backgroundColor: lightThemeVars.color.primary['700Darken'],
+        },
+      },
+      ghost: {
+        border: `1px solid ${lightThemeVars.color.white.hover}`,
+        backgroundColor: lightThemeVars.color.white.main,
+        color: lightThemeVars.color.black,
+        ':hover': {
+          backgroundColor: lightThemeVars.color.white.hover,
+        },
+      },
+    },
+  },
+});

--- a/src/components/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/src/components/UserSettingsDialog/UserSettingsDialog.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+
+import { teamQuery, userQuery } from '@/apis/queries';
+import { useUserSettingsModalStore } from '@/stores';
+
+import * as styles from './UserSettingsDialog.css';
+
+export const UserSettingsDialog = () => {
+  const queryClient = useQueryClient();
+  const { data: teams } = useSuspenseQuery(teamQuery.listAll);
+  const { isOpen, close } = useUserSettingsModalStore();
+  const { data: me } = useSuspenseQuery(userQuery.me);
+  const [selectedTeamId, setSelectedTeamId] = useState<number>(me?.teamId ?? 1);
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const updateSelfTeam = (teamId: number) => {
+    queryClient.setQueryData(userQuery.me.queryKey, prev => {
+      if (!prev) return prev;
+      const updatedUser = {
+        ...prev,
+        teamId,
+      };
+
+      localStorage.setItem('user', JSON.stringify(updatedUser));
+
+      return updatedUser;
+    });
+  };
+
+  const handleSubmit = () => {
+    updateSelfTeam(selectedTeamId);
+    close();
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.close();
+    }
+  }, [isOpen]);
+
+  return (
+    <dialog ref={dialogRef} className={styles.dialog}>
+      <div className={styles.rootContainer}>
+        <h2>개인 설정</h2>
+        <label htmlFor='teamId'>팀 ID</label>
+        <select
+          id='teamId'
+          value={selectedTeamId}
+          onChange={e => setSelectedTeamId(Number(e.target.value))}
+        >
+          {teams.data?.map(team => (
+            <option key={team.id} value={team.id}>
+              [id: {team.id}] {team.name}
+            </option>
+          ))}
+        </select>
+        <div className={styles.footerContainer}>
+          <button
+            className={styles.button({ variant: 'primary' })}
+            onClick={handleSubmit}
+          >
+            저장
+          </button>
+          <button
+            className={styles.button({ variant: 'ghost' })}
+            onClick={close}
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+};

--- a/src/components/UserSettingsDialog/index.ts
+++ b/src/components/UserSettingsDialog/index.ts
@@ -1,0 +1,1 @@
+export * from './UserSettingsDialog';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,3 +19,4 @@ export * from './Navbar';
 export * from './PlayerOnFieldGrid';
 export * from './ToggleableStartingPlayers';
 export * from './SnackbarViewForDebug';
+export * from './UserSettingsDialog';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+import { StrictMode, Suspense } from 'react';
 
 import Hotjar from '@hotjar/browser';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -6,7 +6,7 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { SnackbarProvider } from 'notistack';
 import { createRoot } from 'react-dom/client';
 
-import { SnackbarViewForDebug } from './components';
+import { SnackbarViewForDebug, UserSettingsDialog } from './components';
 import { HOTJAR_SITE_ID, HOTJAR_VERSION } from './constants';
 import { ReactQueryClientProvider } from './react-query-provider';
 import { routeTree } from './routeTree.gen';
@@ -49,6 +49,9 @@ createRoot(document.getElementById('root')!).render(
     >
       <ReactQueryClientProvider>
         <RouterProvider router={router} />
+        <Suspense>
+          <UserSettingsDialog />
+        </Suspense>
         <ReactQueryDevtools position='right' initialIsOpen={false} />
       </ReactQueryClientProvider>
     </SnackbarProvider>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,3 +2,4 @@ export * from './selectedPlayer';
 export * from './playerSubstitution';
 export * from './pageTitle';
 export * from './loggedInUser';
+export * from './userSettingsModal';

--- a/src/stores/userSettingsModal.ts
+++ b/src/stores/userSettingsModal.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface ModalState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+// FIXME: 최소 구현을 위해 zustand store를 사용했는데 추후 개선
+export const useUserSettingsModalStore = create<ModalState>(set => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-260](https://match-day.atlassian.net/browse/MAT-260)
- 유저가 본인의 소속팀을 설정할 수 있게 임시 유저 설정 모달을 추가합니다 (사이드바 > 설정 버튼으로 모달 접근)

## Changes

- [x] 소속팀 설정 모달인 `UserSettingsDialog` 컴포넌트 추가
- [x] 모달 열기 상태를 정의한 `useUserSettingsModalStore` 전역 상태 추가
- [x] 사이드바에서 모달 열 수 있게 설정 버튼 클릭 연동

### Screenshots

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/d61d2767-9a53-4942-8540-215d94c1f754" />

## Todo

- [ ] 모달 상태 관리의 개선 방법 고민
