### PR TITLE
fix: MAT-262 게스트 로그인 직후 튕기는 오류 수정 (invalidate 타이밍 이슈)

### DIFF
--- a/src/apis/mutations/users.ts
+++ b/src/apis/mutations/users.ts
@@ -50,13 +50,13 @@ export const useLoginMutation = () => {
         return Promise.reject(new Error('로그인 실패'));
       });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       enqueueSnackbar('로그인 성공', {
         variant: 'success',
       });
 
       setIsLoggedIn(true);
-      queryClient.invalidateQueries({ queryKey: userQuery.me.queryKey });
+      await queryClient.invalidateQueries({ queryKey: userQuery.me.queryKey });
       navigate({ to: '/' });
     },
     onError: () => {

--- a/src/routes/index/route.tsx
+++ b/src/routes/index/route.tsx
@@ -23,22 +23,25 @@ export const Route = createFileRoute('/')({
 function MyTeamMatchListPage() {
   usePageTitle('매치 리스트');
 
+  // 애초에 유저가 없으면 렌더링이 되면 안 됨
   const { data: user } = useSuspenseQuery(userQuery.me);
+  if (!user) {
+    throw new Error('로그인 없이 인증된 페이지에 접근했습니다');
+  }
+
   const { data: team } = useQuery({
-    ...teamQuery.byId(user!.teamId!),
-    enabled: Boolean(user?.teamId),
+    ...teamQuery.byId(user.teamId),
+    enabled: Boolean(user.teamId),
   });
   const { data: matchList, isLoading } = useQuery({
-    ...matchQuery.list(user!.teamId!),
-    enabled: Boolean(user?.teamId),
+    ...matchQuery.list(user.teamId),
+    enabled: Boolean(user.teamId),
   });
 
   // NOTE: enabled 때문에 타입 가드가 안 됨
   if (isLoading || !matchList || !team) {
     return <CommonLoader />;
   }
-
-  console.log('matches:', matchList);
 
   return (
     <div className={styles.rootContainer}>


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-262](https://match-day.atlassian.net/browse/MAT-262)
- 원인: user 로딩 타이밍 대기 없이 바로 navigate해서 발생
- user는 항상 null일 수 있기 때문에 타입 단언보다 타입 가드 사용

## Changes

- [x] 매치 리스트 페이지에서 `user` 타입 단언 제거 및 `user`가 없으면 오류 던지도록 수정 (현재 플로우 상 레이아웃에서 인증하므로 해당 경우는 발생 불가)

### Screenshots

오류 화면:

<img width="515" alt="image" src="https://github.com/user-attachments/assets/4e814901-a6b0-4e8c-af86-4bcb5105ab44" />
