### PR TITLE
fix: MAT-264 다이렉트 레드 줄 수 있게 개선

### DIFF
--- a/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.tsx
+++ b/src/components/PlayerStatCounterGrid/PlayerStatCounterGrid.tsx
@@ -19,15 +19,12 @@ export const PlayerStatCounterGrid = ({
 }: PlayerStatCounterGridProps) => {
   const { selectedPlayer } = useSelectedPlayerStore();
 
-  const handleCardClick = () => {
+  const handleCardClick = (type: 'yellow' | 'red') => {
     if (!selectedPlayer) {
       return;
     }
 
-    if (
-      selectedPlayer.player.redCards === 0 &&
-      selectedPlayer.player.yellowCards === 0
-    ) {
+    if (type === 'yellow') {
       onStatChange(selectedPlayer.player.id, MatchEventType.YELLOW_CARD);
     } else {
       onStatChange(selectedPlayer.player.id, MatchEventType.RED_CARD);
@@ -84,12 +81,12 @@ export const PlayerStatCounterGrid = ({
               <CardBlock
                 caution='yellow'
                 active={selectedPlayer.player.yellowCards > 0}
-                onClick={handleCardClick}
+                onClick={() => handleCardClick('yellow')}
               />
               <CardBlock
                 caution='red'
                 active={selectedPlayer.player.redCards > 0}
-                onClick={handleCardClick}
+                onClick={() => handleCardClick('red')}
               />
             </div>
           </div>


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-264](https://match-day.atlassian.net/browse/MAT-264) 선수 스텟 증감 영역에서 레드 카드 클릭 시 다이렉트 레드가 주어지도록 개선 (AS-IS: 옐로가 없으면 옐로가 주어지는 방식)

## Changes

- [x] `PlayerStatCounterGrid` 카드 클릭 이벤트 핸들러 로직 변경

### Screenshots

https://github.com/user-attachments/assets/3beea66c-bcb1-46ab-95ee-a672dc126b34

