### PR TITLE
fix: MAT-267 width=1680px일 때 사이드바가 커지지 않고 닫기 버튼만 사라지는 버그 수정

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -12,7 +12,7 @@ interface LayoutProps {
 }
 
 export function Layout({ children }: LayoutProps) {
-  const [isOpen, setIsOpen] = useState(window.innerWidth > SIDEBAR_BREAKPOINT);
+  const [isOpen, setIsOpen] = useState(window.innerWidth >= SIDEBAR_BREAKPOINT);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 
 import { Navbar } from '@/components/Navbar';
 import { Sidebar } from '@/components/Sidebar';
@@ -15,20 +15,17 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   const [isOpen, setIsOpen] = useState(checkIsLargeScreen(window.innerWidth));
-  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
-
     const handleResize = debounce(() => {
-      const width = containerRef.current?.offsetWidth || window.innerWidth;
+      const width = window.innerWidth;
       setIsOpen(checkIsLargeScreen(width));
     }, 100);
 
     handleResize();
 
     const observer = new window.ResizeObserver(handleResize);
-    observer.observe(containerRef.current);
+    observer.observe(window.document.body);
 
     return () => {
       observer.disconnect();
@@ -40,7 +37,7 @@ export function Layout({ children }: LayoutProps) {
   }, []);
 
   return (
-    <div className={styles.layoutContainer} ref={containerRef}>
+    <div className={styles.layoutContainer}>
       <Sidebar isOpen={isOpen} toggle={toggle} />
       <div className={styles.mainContent}>
         <Navbar isOpen={isOpen} />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,12 +7,14 @@ import { debounce } from '@/utils/debounce';
 
 import * as styles from './Layout.css';
 
+const checkIsLargeScreen = (width: number) => width >= SIDEBAR_BREAKPOINT;
+
 interface LayoutProps {
   children: ReactNode;
 }
 
 export function Layout({ children }: LayoutProps) {
-  const [isOpen, setIsOpen] = useState(window.innerWidth >= SIDEBAR_BREAKPOINT);
+  const [isOpen, setIsOpen] = useState(checkIsLargeScreen(window.innerWidth));
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -20,8 +22,7 @@ export function Layout({ children }: LayoutProps) {
 
     const handleResize = debounce(() => {
       const width = containerRef.current?.offsetWidth || window.innerWidth;
-      const isSmallScreen = width <= SIDEBAR_BREAKPOINT;
-      setIsOpen(!isSmallScreen);
+      setIsOpen(checkIsLargeScreen(width));
     }, 100);
 
     handleResize();


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-267](https://match-day.atlassian.net/browse/MAT-267)
- `window.innerWidth = 1680px`일 때 여닫기 버튼은 사라지는데 사이드바 패널은 열리지 않은 상태로 유지되는 버그 존재
- 1681px이 되면 사이드바 패널이 열리며 정상 상태로 바뀌게 됨

## Changes

- [x] 1680px일 때 패널이 열리게 개선
- [x] width 경계 판단 코드 중복, 불필요한 ref 코드 제거
