### PR TITLE
feat: MAT-283 Label 공통 컴포넌트 구현

### DIFF
--- a/src/components/CommonForm/Label/Label.css.ts
+++ b/src/components/CommonForm/Label/Label.css.ts
@@ -1,0 +1,25 @@
+import { style } from '@vanilla-extract/css';
+
+import { lightThemeVars } from '@/styles/theme.css';
+
+export const textFieldLabel = style({
+  display: 'flex',
+  alignItems: 'center',
+  alignSelf: 'stretch',
+  gap: 2,
+  padding: '0 4px',
+  lineHeight: '140%',
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.black,
+  fontFamily: 'Pretendard Variable',
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const textFieldRequired = style({
+  lineHeight: '140%',
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.primary[700],
+  fontSize: 14,
+  fontWeight: 600,
+});

--- a/src/components/CommonForm/Label/Label.css.ts
+++ b/src/components/CommonForm/Label/Label.css.ts
@@ -8,16 +8,15 @@ export const textFieldLabel = style({
   alignSelf: 'stretch',
   gap: 2,
   padding: '0 4px',
-  lineHeight: '140%',
+  lineHeight: 1.4,
   letterSpacing: -0.35,
   color: lightThemeVars.color.black,
-  fontFamily: 'Pretendard Variable',
   fontSize: 14,
   fontWeight: 500,
 });
 
 export const textFieldRequired = style({
-  lineHeight: '140%',
+  lineHeight: 1.4,
   letterSpacing: -0.35,
   color: lightThemeVars.color.primary[700],
   fontSize: 14,

--- a/src/components/CommonForm/Label/Label.stories.tsx
+++ b/src/components/CommonForm/Label/Label.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Label } from './Label';
+import * as styles from './Label.css';
+
+const meta: Meta<typeof Label> = {
+  title: 'CommonForm/Label',
+  component: Label,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className={styles.textFieldLabel}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  args: {
+    label: '팀 이름',
+    required: false,
+  },
+  render: args => <Label {...args}> </Label>,
+};
+
+export const Required: Story = {
+  args: {
+    label: '팀 이름',
+    required: true,
+  },
+  render: args => <Label {...args}></Label>,
+};

--- a/src/components/CommonForm/Label/Label.stories.tsx
+++ b/src/components/CommonForm/Label/Label.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { lightThemeVars } from '@/styles/theme.css';
+
 import { Label } from './Label';
-import * as styles from './Label.css';
 
 const meta: Meta<typeof Label> = {
   title: 'CommonForm/Label',
@@ -12,7 +13,7 @@ const meta: Meta<typeof Label> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div className={styles.textFieldLabel}>
+      <div style={{ padding: '20px' }}>
         <Story />
       </div>
     ),
@@ -22,12 +23,32 @@ const meta: Meta<typeof Label> = {
 export default meta;
 type Story = StoryObj<typeof Label>;
 
+const inputstyle = {
+  marginTop: 12,
+  padding: '9px 16px',
+  border: `1px solid ${lightThemeVars.color.primary[100]}`,
+  borderRadius: 4,
+  background: lightThemeVars.color.white.hover,
+  color: lightThemeVars.color.gray[300],
+  fontSize: 14,
+  width: '100%',
+};
+
 export const Default: Story = {
   args: {
     label: '팀 이름',
     required: false,
   },
-  render: args => <Label {...args}> </Label>,
+  render: args => (
+    <div>
+      <Label {...args} />
+      <input
+        type='text'
+        placeholder='팀 이름을 입력해주세요'
+        style={inputstyle}
+      />
+    </div>
+  ),
 };
 
 export const Required: Story = {
@@ -35,5 +56,14 @@ export const Required: Story = {
     label: '팀 이름',
     required: true,
   },
-  render: args => <Label {...args}></Label>,
+  render: args => (
+    <div>
+      <Label {...args} />
+      <input
+        type='text'
+        placeholder='팀 이름을 입력해주세요'
+        style={inputstyle}
+      />
+    </div>
+  ),
 };

--- a/src/components/CommonForm/Label/Label.tsx
+++ b/src/components/CommonForm/Label/Label.tsx
@@ -1,22 +1,16 @@
-import { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 import * as styles from './Label.css';
 
 interface LabelProps extends ComponentPropsWithoutRef<'label'> {
   label: string;
-  children?: ReactNode;
   required?: boolean;
 }
 
-export const Label = ({
-  label,
-  children,
-  required = false,
-  ...rest
-}: LabelProps) => (
-  <label className={styles.textFieldLabel} {...rest}>
+export const Label = ({ label, required = false, ...props }: LabelProps) => (
+  <label className={styles.textFieldLabel} {...props}>
     {label}
     {required && <span className={styles.textFieldRequired}>*</span>}
-    {children}
+    {props.children}
   </label>
 );

--- a/src/components/CommonForm/Label/Label.tsx
+++ b/src/components/CommonForm/Label/Label.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+import * as styles from './Label.css';
+
+type LabelProps = {
+  label: string;
+  children: ReactNode;
+  required: boolean;
+};
+
+export const Label = ({ label, children, required }: LabelProps) => (
+  <label className={styles.textFieldLabel}>
+    {label}
+    {required && <span className={styles.textFieldRequired}>*</span>}
+    {children}
+  </label>
+);

--- a/src/components/CommonForm/Label/Label.tsx
+++ b/src/components/CommonForm/Label/Label.tsx
@@ -2,13 +2,13 @@ import { ReactNode } from 'react';
 
 import * as styles from './Label.css';
 
-type LabelProps = {
+interface LabelProps {
   label: string;
-  children: ReactNode;
-  required: boolean;
-};
+  children?: ReactNode;
+  required?: boolean;
+}
 
-export const Label = ({ label, children, required }: LabelProps) => (
+export const Label = ({ label, children, required = false }: LabelProps) => (
   <label className={styles.textFieldLabel}>
     {label}
     {required && <span className={styles.textFieldRequired}>*</span>}

--- a/src/components/CommonForm/Label/Label.tsx
+++ b/src/components/CommonForm/Label/Label.tsx
@@ -1,15 +1,20 @@
-import { ReactNode } from 'react';
+import { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 import * as styles from './Label.css';
 
-interface LabelProps {
+interface LabelProps extends ComponentPropsWithoutRef<'label'> {
   label: string;
   children?: ReactNode;
   required?: boolean;
 }
 
-export const Label = ({ label, children, required = false }: LabelProps) => (
-  <label className={styles.textFieldLabel}>
+export const Label = ({
+  label,
+  children,
+  required = false,
+  ...rest
+}: LabelProps) => (
+  <label className={styles.textFieldLabel} {...rest}>
     {label}
     {required && <span className={styles.textFieldRequired}>*</span>}
     {children}

--- a/src/components/CommonForm/Label/index.ts
+++ b/src/components/CommonForm/Label/index.ts
@@ -1,0 +1,1 @@
+export * from './Label';

--- a/src/components/CommonForm/index.ts
+++ b/src/components/CommonForm/index.ts
@@ -1,0 +1,1 @@
+export * from './Label';


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-283](https://match-day.atlassian.net/browse/MAT-283)
- 공통 컴포넌트 Label 구현

## Changes
- [x] 필수값인 경우 * 표시 기능 
- [x] 공통 컴포넌트 Label Storybook 문서화

## 1차 리뷰 반영
- [x] required prop의 기본값을 false로 지정
- [x]  Storybook children 추가, decorators 에서 textFieldLabel 스타일 제거
- [x] CommonForm, Label components barrel file 추가

## 2차 리뷰 반영
- [x] ComponentPropsWithoutRef<'label'> 사용해 기본 label props 지원
- [x] rest → props로 변수명 변경,  interface에서 children 타입 제거