### PR TITLE
fix: MAT-304 웹소켓 오류 채널 구독 분리해 반복되는 에러 메시지 표시 문제 수정

### DIFF
--- a/src/features/matchRecord/index.ts
+++ b/src/features/matchRecord/index.ts
@@ -1,2 +1,3 @@
-export * from './useMatchRecordWebSocket';
+export * from './useMatchRecordWsMutation';
+export * from './useMatchRecordWsSubscribe';
 export * from './useSyncMatchMemo';

--- a/src/features/matchRecord/useMatchRecordWsMutation.ts
+++ b/src/features/matchRecord/useMatchRecordWsMutation.ts
@@ -1,0 +1,39 @@
+import { getWebSocketApi } from '@/apis/websockets';
+import { MatchEventType } from '@/constants';
+
+export const useMatchRecordWsMutation = (matchId: number) => {
+  const wsApi = getWebSocketApi();
+
+  const requestPlayerSwap = (inPlayerId: number, outPlayerId: number) => {
+    wsApi.send('recordPlayerExchange', [matchId], {
+      fromMatchUserId: outPlayerId,
+      toMatchUserId: inPlayerId,
+    });
+  };
+
+  // FIXME: 생략된 prop: isIncrement: boolean - 현재는 항상 증가만 가능
+  const requestTeamStatChange = (
+    matchEvent: MatchEventType,
+    teamId: number,
+  ) => {
+    wsApi.send('recordTeamStat', [matchId, teamId], {
+      eventType: matchEvent,
+    });
+  };
+
+  const requestPlayerStatChange = (
+    playerId: number,
+    matchEvent: MatchEventType,
+  ) => {
+    wsApi.send('recordPlayerStat', [matchId], {
+      matchUserId: playerId,
+      eventType: matchEvent,
+    });
+  };
+
+  return {
+    requestPlayerSwap,
+    requestTeamStatChange,
+    requestPlayerStatChange,
+  };
+};

--- a/src/features/matchRecord/useMatchRecordWsSubscribe.ts
+++ b/src/features/matchRecord/useMatchRecordWsSubscribe.ts
@@ -5,9 +5,8 @@ import { useSnackbar } from 'notistack';
 
 import { matchQuery } from '@/apis/queries';
 import { getWebSocketApi } from '@/apis/websockets';
-import { MatchEventType } from '@/constants';
 
-export const useMatchRecordWebSocket = (matchId: number) => {
+export const useMatchRecordWsSubscribe = (matchId: number) => {
   const queryClient = useQueryClient();
   const { enqueueSnackbar } = useSnackbar();
   const wsApi = getWebSocketApi();
@@ -70,37 +69,4 @@ export const useMatchRecordWebSocket = (matchId: number) => {
       unsubMatchChannel();
     };
   }, [matchId, wsApi, enqueueSnackbar, queryClient]);
-
-  const requestPlayerSwap = (inPlayerId: number, outPlayerId: number) => {
-    wsApi.send('recordPlayerExchange', [matchId], {
-      fromMatchUserId: outPlayerId,
-      toMatchUserId: inPlayerId,
-    });
-  };
-
-  // FIXME: 생략된 prop: isIncrement: boolean - 현재는 항상 증가만 가능
-  const requestTeamStatChange = (
-    matchEvent: MatchEventType,
-    teamId: number,
-  ) => {
-    wsApi.send('recordTeamStat', [matchId, teamId], {
-      eventType: matchEvent,
-    });
-  };
-
-  const requestPlayerStatChange = (
-    playerId: number,
-    matchEvent: MatchEventType,
-  ) => {
-    wsApi.send('recordPlayerStat', [matchId], {
-      matchUserId: playerId,
-      eventType: matchEvent,
-    });
-  };
-
-  return {
-    requestPlayerSwap,
-    requestTeamStatChange,
-    requestPlayerStatChange,
-  };
 };

--- a/src/features/playerSubstitution/PlayerSubstitutionAdapter.tsx
+++ b/src/features/playerSubstitution/PlayerSubstitutionAdapter.tsx
@@ -1,7 +1,7 @@
 import { DragEvent, ReactElement } from 'react';
 
 import { MatchUserResponse, TeamResponse } from '@/apis/models';
-import { useMatchRecordWebSocket } from '@/features/matchRecord';
+import { useMatchRecordWsMutation } from '@/features/matchRecord';
 import { useIsDragOver } from '@/hooks';
 
 import * as policies from './playerSubstitutionPolicy';
@@ -38,7 +38,7 @@ export const PlayerSubstitutionAdapter = <Target extends HTMLElement>({
   const { isDragOver, hoverTargetRef } = useIsDragOver<Target>();
   const { getIsSubstitutionTarget, beginSubstitution, finishSubstitution } =
     useSubstitutionStore();
-  const { requestPlayerSwap } = useMatchRecordWebSocket(matchId);
+  const { requestPlayerSwap } = useMatchRecordWsMutation(matchId);
 
   const isAvailable =
     policies.checkPlayerAvailable[mode](player) &&

--- a/src/routes/matches/$matchId/record/route.tsx
+++ b/src/routes/matches/$matchId/record/route.tsx
@@ -15,7 +15,8 @@ import {
   TeamStatCounterGrid,
 } from '@/components';
 import {
-  useMatchRecordWebSocket,
+  useMatchRecordWsMutation,
+  useMatchRecordWsSubscribe,
   useSyncMatchMemo,
 } from '@/features/matchRecord';
 import {
@@ -50,8 +51,9 @@ export const Route = createFileRoute('/matches/$matchId/record')({
 function MatchRecordPage() {
   const { matchId: _matchId } = useParams({ from: '/matches/$matchId/record' });
   const matchId = Number(_matchId);
+  useMatchRecordWsSubscribe(matchId);
   const { requestTeamStatChange, requestPlayerStatChange } =
-    useMatchRecordWebSocket(matchId);
+    useMatchRecordWsMutation(matchId);
 
   const { memo, updateMemo } = useSyncMatchMemo(matchId);
   const { data: matchInfo } = useSuspenseQuery(matchQuery.info(matchId));


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-304](https://match-day.atlassian.net/browse/MAT-304) 
- 각 선수 칸에서도 동일 ws 훅을 사용하고 있어 선수 수만큼 리스너가 추가됨
- 선수 컴포넌트는 요청만 수행하므로 리스너 구독을 하는 훅을 분리

## Changes

- [x] `useMatchRecordWebSocket` 훅을 `useMatchRecordWsMutation`, `useMatchRecordWsSubscribe`로 분리