### PR TITLE
feat: MAT-334 Select 컴포넌트 커스터마이징 (Option UI 커스텀, 키보드 네비게이션)

### DIFF
--- a/src/components/CommonForm/Label/Label.css.ts
+++ b/src/components/CommonForm/Label/Label.css.ts
@@ -7,6 +7,7 @@ export const rootContainer = style({
   flexDirection: 'column',
   alignSelf: 'stretch',
   gap: 4,
+  minWidth: 0, // NOTE: 기본값이 min-width: auto이며 flex:1, width:100% 으로 작아지지 않음
   lineHeight: 1.4,
   letterSpacing: -0.35,
   color: lightThemeVars.color.black,

--- a/src/components/CommonForm/Select/Select.css.ts
+++ b/src/components/CommonForm/Select/Select.css.ts
@@ -4,6 +4,9 @@ import { lightThemeRawValues, lightThemeVars } from 'src/styles/theme.css';
 
 import { hexColorAlpha } from '@/utils/colorUtils';
 
+export const OPTION_ITEM_HEIGHT = 38;
+export const DROPDOWN_LIST_HEIGHT = 208;
+
 export const selectContainer = style({
   position: 'relative',
   width: '100%',
@@ -22,7 +25,7 @@ export const selectButton = recipe({
     cursor: 'pointer',
     padding: '7px 14px',
     width: '100%',
-    height: 38,
+    height: OPTION_ITEM_HEIGHT,
     lineHeight: 1.4,
     letterSpacing: -0.35,
     fontSize: 14,
@@ -90,18 +93,33 @@ export const chevronIcon = recipe({
   },
 });
 
-export const optionsContainer = style({
-  position: 'absolute',
-  zIndex: 1000,
-  top: 'calc(100% + 2px)',
-  right: 0,
-  left: 0,
-  border: `1px solid ${lightThemeVars.color.primary[100]}`,
-  borderRadius: 6,
-  boxShadow: '0px 4px 4px 0px rgba(0, 0, 0, 0.05)',
-  backgroundColor: lightThemeVars.color.white.main,
-  maxHeight: 208,
-  overflow: 'auto',
+export const optionsContainer = recipe({
+  base: {
+    position: 'absolute',
+    zIndex: 1000,
+    right: 0,
+    left: 0,
+    border: `1px solid ${lightThemeVars.color.primary[100]}`,
+    borderRadius: 6,
+    boxShadow: '0px 4px 4px 0px rgba(0, 0, 0, 0.05)',
+    backgroundColor: lightThemeVars.color.white.main,
+    maxHeight: DROPDOWN_LIST_HEIGHT,
+    overflow: 'auto',
+  },
+  variants: {
+    position: {
+      bottom: {
+        top: 'calc(100% + 2px)',
+      },
+      top: {
+        bottom: 'calc(100% + 2px)',
+        boxShadow: '0px -4px 4px 0px rgba(0, 0, 0, 0.05)',
+      },
+    },
+  },
+  defaultVariants: {
+    position: 'bottom',
+  },
 });
 
 export const option = recipe({
@@ -124,6 +142,11 @@ export const option = recipe({
       true: {
         backgroundColor: lightThemeVars.color.white.hover,
         fontWeight: 500,
+      },
+    },
+    isFocused: {
+      true: {
+        backgroundColor: lightThemeVars.color.primary[100],
       },
     },
   },

--- a/src/components/CommonForm/Select/Select.css.ts
+++ b/src/components/CommonForm/Select/Select.css.ts
@@ -9,33 +9,30 @@ export const selectContainer = style({
   width: '100%',
 });
 
-export const select = recipe({
+export const selectButton = recipe({
   base: {
     boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     outline: '1px solid transparent',
     border: `1px solid ${lightThemeVars.color.primary[100]}`,
     borderRadius: 6,
     backgroundColor: lightThemeVars.color.white.hover,
+    cursor: 'pointer',
     padding: '7px 14px',
-    paddingRight: 38,
     width: '100%',
     height: 38,
     lineHeight: 1.4,
     letterSpacing: -0.35,
-    color: lightThemeVars.color.black,
     fontSize: 14,
     fontWeight: 400,
 
     ':focus': {
       outlineColor: lightThemeVars.color.primary[700],
     },
-    selectors: {
-      '&[aria-invalid="true"]': {
-        borderColor: lightThemeVars.color.warning,
-      },
-      '&[aria-invalid="true"]:focus': {
-        outlineColor: hexColorAlpha(lightThemeRawValues.color.warning, 80),
-      },
+    ':hover': {
+      backgroundColor: lightThemeVars.color.white.hover,
     },
   },
   variants: {
@@ -43,17 +40,91 @@ export const select = recipe({
       true: {
         color: lightThemeVars.color.gray[500],
       },
+      false: {
+        color: lightThemeVars.color.black,
+      },
+    },
+    isError: {
+      true: {
+        borderColor: lightThemeVars.color.warning,
+      },
+    },
+  },
+  compoundVariants: [
+    {
+      variants: { isError: true },
+      style: {
+        ':focus': {
+          outlineColor: hexColorAlpha(lightThemeRawValues.color.warning, 80),
+        },
+      },
+    },
+  ],
+});
+
+export const selectText = style({
+  flex: 1,
+  overflow: 'hidden',
+  textAlign: 'left',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const chevronIcon = recipe({
+  base: {
+    flexShrink: 0,
+    transition: 'transform 0.2s ease',
+    width: 24,
+    height: 24,
+    color: lightThemeVars.color.gray[500],
+  },
+  variants: {
+    isOpen: {
+      true: {
+        transform: 'rotate(-180deg)',
+      },
+      false: {
+        transform: 'rotate(0deg)',
+      },
     },
   },
 });
 
-export const chevronIcon = style({
+export const optionsContainer = style({
   position: 'absolute',
-  top: '50%',
-  right: 14,
-  transform: 'translateY(-50%)',
-  pointerEvents: 'none',
-  width: 24,
-  height: 24,
-  color: lightThemeVars.color.gray[500],
+  zIndex: 1000,
+  top: 'calc(100% + 2px)',
+  right: 0,
+  left: 0,
+  border: `1px solid ${lightThemeVars.color.primary[100]}`,
+  borderRadius: 6,
+  boxShadow: '0px 4px 4px 0px rgba(0, 0, 0, 0.05)',
+  backgroundColor: lightThemeVars.color.white.main,
+  maxHeight: 208,
+  overflow: 'auto',
+});
+
+export const option = recipe({
+  base: {
+    backgroundColor: lightThemeVars.color.white.main,
+    cursor: 'pointer',
+    padding: '9px 14px',
+    lineHeight: 1.4,
+    letterSpacing: -0.35,
+    color: lightThemeVars.color.black,
+    fontSize: 14,
+    fontWeight: 400,
+
+    ':hover': {
+      backgroundColor: lightThemeVars.color.white.hover,
+    },
+  },
+  variants: {
+    isSelected: {
+      true: {
+        backgroundColor: lightThemeVars.color.white.hover,
+        fontWeight: 500,
+      },
+    },
+  },
 });

--- a/src/components/CommonForm/Select/Select.stories.tsx
+++ b/src/components/CommonForm/Select/Select.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Select> = {
       <div
         style={{
           width: '300px',
+          height: '300px',
         }}
       >
         <Story />
@@ -80,13 +81,7 @@ export const Interactive: Story = {
   render: args => {
     const [value, setValue] = useState(args.value);
 
-    return (
-      <Select
-        {...args}
-        value={value}
-        onChange={e => setValue(e.target.value)}
-      />
-    );
+    return <Select {...args} value={value} onChange={setValue} />;
   },
   args: {
     options: positionOptions,

--- a/src/components/CommonForm/Select/Select.stories.tsx
+++ b/src/components/CommonForm/Select/Select.stories.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Select } from './Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'CommonForm/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: '300px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+const sampleOptions = [
+  { value: 'football', label: '축구' },
+  { value: 'basketball', label: '농구' },
+  { value: 'volleyball', label: '배구' },
+  { value: 'tennis', label: '테니스' },
+  { value: 'baseball', label: '야구' },
+];
+
+const positionOptions = [
+  { value: 'forward', label: '공격수' },
+  { value: 'midfielder', label: '미드필더' },
+  { value: 'defender', label: '수비수' },
+  { value: 'goalkeeper', label: '골키퍼' },
+];
+
+export const DefaultWithPlaceholder: Story = {
+  args: {
+    options: sampleOptions,
+    placeholder: '종목을 선택해주세요',
+    isError: false,
+  },
+};
+
+export const DefaultWithValue: Story = {
+  args: {
+    options: sampleOptions,
+    placeholder: '종목을 선택해주세요',
+    value: 'football',
+    isError: false,
+  },
+};
+
+export const ErrorWithPlaceholder: Story = {
+  args: {
+    options: sampleOptions,
+    placeholder: '종목을 선택해주세요',
+    isError: true,
+  },
+};
+
+export const ErrorWithValue: Story = {
+  args: {
+    options: sampleOptions,
+    placeholder: '종목을 선택해주세요',
+    value: 'football',
+    isError: true,
+  },
+};
+
+export const Interactive: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value);
+
+    return (
+      <Select
+        {...args}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      />
+    );
+  },
+  args: {
+    options: positionOptions,
+    placeholder: '포지션을 선택해주세요',
+    isError: false,
+  },
+};

--- a/src/routes/matches/create/-components/MatchCreateForm/MatchCreateForm.tsx
+++ b/src/routes/matches/create/-components/MatchCreateForm/MatchCreateForm.tsx
@@ -136,11 +136,7 @@ export const MatchCreateForm = ({
                   options={teamOptions}
                   placeholder='소속팀을 선택해주세요.'
                   value={field.value ? field.value.toString() : ''}
-                  onChange={e =>
-                    field.onChange(
-                      e.target.value ? Number(e.target.value) : undefined,
-                    )
-                  }
+                  onChange={value => field.onChange(Number(value))}
                   isError={!!errors.homeTeamId}
                 />
               )}
@@ -156,11 +152,7 @@ export const MatchCreateForm = ({
                   options={teamOptions}
                   placeholder='상대팀을 선택해주세요.'
                   value={field.value ? field.value.toString() : ''}
-                  onChange={e =>
-                    field.onChange(
-                      e.target.value ? Number(e.target.value) : undefined,
-                    )
-                  }
+                  onChange={value => field.onChange(Number(value))}
                   isError={!!errors.awayTeamId}
                 />
               )}

--- a/src/routes/teams/create/-components/TeamCreateForm.css.ts
+++ b/src/routes/teams/create/-components/TeamCreateForm.css.ts
@@ -131,6 +131,7 @@ export const fieldGroup = style({
   flexDirection: 'column',
   marginTop: 24,
   width: '100%',
+  minWidth: 0, // NOTE: 기본값이 min-width: auto이며 flex:1, width:100% 으로 작아지지 않음
   lineHeight: 1.4,
 });
 


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-334](https://match-day.atlassian.net/browse/MAT-334)
- 공통 Select의 Option UI를 커스텀하기 위해 `<div>` 기반으로 구현
- 키보드 네비게이션 지원
- 잔여 viewport 높이에 따라 Option List를 상단에 띄움

## Changes

- [x] Select 컴포넌트 Story 추가
- [x] Select 컴포넌트 Option UI 커스텀
- [x] Select 컴포넌트의 키보드 네비게이션 접근성 (엔터, 방향키로 열고, 이동하고 선택)

### Screenshots

[스토리북 참고](https://680b08a7575f04471f05ad14-jrcpgwamqd.chromatic.com/)

https://github.com/user-attachments/assets/09c5e2f9-3e53-4dbe-ad22-ff951efb1916

## Todo

- [ ] 코드 리팩토링
- [ ] Focus가 갇히는 현상 발생 (탭을 2번 입력해야 이동 가능)