### PR TITLE
fix: MAT-338 cloudflare로 배포 시 루트가 아닌 주소 접근 시 404 뜨는 점 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,8 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": null
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
   "name": "matchday-client",
   "compatibility_date": "2025-06-02",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
   }
 }


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-338](https://match-day.atlassian.net/browse/MAT-338)

## Changes

- [x] cloudflare worker의 redirection 설정을 추가해 / 이외의 주소 접근 시에도 화면이 표시되게 개선
- [x] jsonc 포맷팅 시 자꾸 ,를 붙이는 문제가 있어 포매터를 기본으로 변경

### Screenshots

| AS-IS | TO-BE |
|------------|-------------|
| ![image1](https://github.com/user-attachments/assets/5857fc4d-2d57-4654-a101-9ff3816a1bea) | ![image2](https://github.com/user-attachments/assets/f26670f7-52ea-45a7-8203-02b463ded97d) |
