### PR TITLE
feat: 팀 프로필 페이지 퍼블리싱

### DIFF
--- a/src/assets/icons/chevron-left.svg
+++ b/src/assets/icons/chevron-left.svg
@@ -1,0 +1,3 @@
+<svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <path d='M15 18L9 12L15 6' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
+</svg>

--- a/src/assets/icons/chevron-right.svg
+++ b/src/assets/icons/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <path d='M9 18L15 12L9 6' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
+</svg>

--- a/src/assets/icons/crown.svg
+++ b/src/assets/icons/crown.svg
@@ -1,0 +1,4 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M23.3334 10.0265V22.0606H4.66669V10.0265L9.33335 14.7947L14 5.93939L18.6667 14.7947L23.3334 10.0265Z"
+        stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -27,3 +27,5 @@ export { default as CrownIcon } from './crown.svg?react';
 export { default as LoaderIcon } from './loader.svg?react';
 export { default as MapIcon } from './map.svg?react';
 export { default as UsersIcon } from './users.svg?react';
+export { default as JerseyIcon } from './jersey.svg?react';
+export { default as ShortsIcon } from './shorts.svg?react';

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -21,3 +21,7 @@ export { default as MagnifyingGlassIcon } from './magnifying-glass.svg?react';
 export { default as CheckboxCheckIcon } from './checkbox-check.svg?react';
 export { default as SoccerBallBoxyIcon } from './soccer-ball-boxy.svg?react';
 export { default as ArrowRightIcon } from './arrow-right.svg?react';
+export { default as CrownIcon } from './crown.svg?react';
+export { default as LoaderIcon } from './loader.svg?react';
+export { default as MapIcon } from './map.svg?react';
+export { default as UsersIcon } from './users.svg?react';

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -16,6 +16,8 @@ export { default as SeoulLogo } from './seoul-team.png';
 export { default as SuwonLogo } from './suwon-team.png';
 export { default as ExclamationIcon } from './exclamation.svg?react';
 export { default as ChevronDownIcon } from './chevron-down.svg?react';
+export { default as ChevronLeftIcon } from './chevron-left.svg?react';
+export { default as ChevronRightIcon } from './chevron-right.svg?react';
 export { default as FootballShoeIcon } from './football-shoe.svg?react';
 export { default as MagnifyingGlassIcon } from './magnifying-glass.svg?react';
 export { default as CheckboxCheckIcon } from './checkbox-check.svg?react';

--- a/src/assets/icons/jersey.svg
+++ b/src/assets/icons/jersey.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shirt-icon lucide-shirt">
+    <path
+        d="M20.38 3.46 16 2a4 4 0 0 1-8 0L3.62 3.46a2 2 0 0 0-1.34 2.23l.58 3.47a1 1 0 0 0 .99.84H6v10c0 1.1.9 2 2 2h8a2 2 0 0 0 2-2V10h2.15a1 1 0 0 0 .99-.84l.58-3.47a2 2 0 0 0-1.34-2.23z" />
+</svg>

--- a/src/assets/icons/loader.svg
+++ b/src/assets/icons/loader.svg
@@ -1,0 +1,18 @@
+<svg width="29" height="28" viewBox="0 0 29 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M14.75 2.33334V7.00001" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M14.75 21V25.6667" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M6.50134 5.75159L9.80301 9.05325" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M19.6969 18.9467L22.9986 22.2483" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M3.08337 14H7.75004" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M21.75 14H26.4167" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M6.50134 22.2483L9.80301 18.9467" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M19.6969 9.05325L22.9986 5.75159" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+</svg>

--- a/src/assets/icons/map.svg
+++ b/src/assets/icons/map.svg
@@ -1,0 +1,9 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M1.16663 7.00001V25.6667L9.33329 21L18.6666 25.6667L26.8333 21V2.33334L18.6666 7.00001L9.33329 2.33334L1.16663 7.00001Z"
+        stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M9.33337 2.33334V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+    <path d="M18.6666 7V25.6667" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+        stroke-linejoin="round" />
+</svg>

--- a/src/assets/icons/shorts.svg
+++ b/src/assets/icons/shorts.svg
@@ -1,0 +1,5 @@
+<svg width='15' height='13' viewBox='0 0 15 13' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <path
+        d='M0.932617 11.5781L2.24616 1.72632H12.7545L14.0681 11.5781H8.15712L7.50034 7.47319L6.84357 11.5781H0.932617Z'
+        stroke='currentColor' strokeWidth='1.5' strokeLinejoin='round' />
+</svg>

--- a/src/assets/icons/users.svg
+++ b/src/assets/icons/users.svg
@@ -1,0 +1,21 @@
+<svg width="29" height="28" viewBox="0 0 29 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_2941_33249)">
+        <path
+            d="M20.0833 24.5V22.1667C20.0833 20.929 19.5916 19.742 18.7165 18.8668C17.8413 17.9917 16.6543 17.5 15.4166 17.5H6.08329C4.84562 17.5 3.65863 17.9917 2.78346 18.8668C1.90829 19.742 1.41663 20.929 1.41663 22.1667V24.5"
+            stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        <path
+            d="M10.75 12.8333C13.3274 12.8333 15.4167 10.744 15.4167 8.16667C15.4167 5.58934 13.3274 3.5 10.75 3.5C8.17271 3.5 6.08337 5.58934 6.08337 8.16667C6.08337 10.744 8.17271 12.8333 10.75 12.8333Z"
+            stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        <path
+            d="M27.0834 24.4999V22.1665C27.0826 21.1325 26.7385 20.1281 26.105 19.3109C25.4715 18.4937 24.5845 17.91 23.5834 17.6515"
+            stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        <path
+            d="M18.9166 3.65152C19.9204 3.90854 20.8102 4.49234 21.4455 5.31088C22.0809 6.12943 22.4258 7.13615 22.4258 8.17235C22.4258 9.20855 22.0809 10.2153 21.4455 11.0338C20.8102 11.8524 19.9204 12.4362 18.9166 12.6932"
+            stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+    <defs>
+        <clipPath id="clip0_2941_33249">
+            <rect width="28" height="28" fill="white" transform="translate(0.25)" />
+        </clipPath>
+    </defs>
+</svg>

--- a/src/components/Layout/Layout.css.ts
+++ b/src/components/Layout/Layout.css.ts
@@ -2,11 +2,7 @@ import { lightThemeVars } from '@/styles/theme.css';
 
 import { style } from '@vanilla-extract/css';
 
-import {
-  NAVBAR_HEIGHT,
-  SIDEBAR_BREAKPOINT,
-  SIDEBAR_WIDTH_SMALL,
-} from '@/constants';
+import { NAVBAR_HEIGHT } from '@/constants';
 
 export const layoutContainer = style({
   display: 'flex',
@@ -28,10 +24,4 @@ export const contentArea = style({
   flex: 1,
   backgroundColor: lightThemeVars.color.white.background,
   paddingTop: NAVBAR_HEIGHT,
-
-  '@media': {
-    [`(max-width: ${SIDEBAR_BREAKPOINT}px)`]: {
-      paddingLeft: SIDEBAR_WIDTH_SMALL,
-    },
-  },
 });

--- a/src/components/Sidebar/Sidebar.css.ts
+++ b/src/components/Sidebar/Sidebar.css.ts
@@ -3,11 +3,7 @@ import { lightThemeVars } from '@/styles/theme.css';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import {
-  SIDEBAR_BREAKPOINT,
-  SIDEBAR_WIDTH,
-  SIDEBAR_WIDTH_SMALL,
-} from '@/constants';
+import { SIDEBAR_WIDTH, SIDEBAR_WIDTH_SMALL } from '@/constants';
 
 import {
   footer,
@@ -30,12 +26,6 @@ export const container = recipe({
     borderRight: `1px solid ${lightThemeVars.color.gray[100]}`,
     backgroundColor: lightThemeVars.color.white.main,
     height: '100dvh',
-
-    '@media': {
-      [`(max-width: ${SIDEBAR_BREAKPOINT - 1}px)`]: {
-        position: 'fixed',
-      },
-    },
   },
   variants: {
     isOpen: {
@@ -122,7 +112,7 @@ export const toggleButton = style({
   zIndex: 1,
   top: '50%',
   right: -16,
-  display: 'flex',
+  display: 'none',
   alignItems: 'center',
   justifyContent: 'center',
   clipPath: 'inset(0 0 0 50%)',
@@ -133,12 +123,6 @@ export const toggleButton = style({
   cursor: 'pointer',
   width: 36,
   height: 36,
-
-  '@media': {
-    [`(min-width: ${SIDEBAR_BREAKPOINT}px)`]: {
-      display: 'none',
-    },
-  },
 
   selectors: {
     '&::after': {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from 'react';
 
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { userQuery } from '@/apis/queries';
 import {
   CheckRightIcon,
   HelpCircleIcon,
@@ -26,12 +29,18 @@ interface SidebarProps {
 
 export function Sidebar({ isOpen, toggle }: SidebarProps) {
   const { open } = useUserSettingsModalStore();
+  const { data: user } = useSuspenseQuery(userQuery.me);
 
   const navItems = [
     {
       to: '/',
       icon: <HomeIcon className={styles.icon} />,
       label: '팀 매치 리스트',
+    },
+    {
+      to: `/teams/${user?.teamId}`,
+      icon: <HomeIcon className={styles.icon} />,
+      label: '팀 프로필',
     },
     {
       to: '/matches/create',
@@ -75,6 +84,7 @@ export function Sidebar({ isOpen, toggle }: SidebarProps) {
         <CheckRightIcon
           className={`${styles.rightIcon} ${isOpen ? styles.rotateIcon : ''}`}
         />
+        hello
       </button>
 
       <div className={styles.logo({ isOpen })}>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as LoginRouteImport } from './routes/login/route'
 import { Route as IndexRouteImport } from './routes/index/route'
 import { Route as UsersCreateRouteImport } from './routes/users/create/route'
 import { Route as TeamsCreateRouteImport } from './routes/teams/create/route'
+import { Route as TeamsTeamIdRouteImport } from './routes/teams/$teamId/route'
 import { Route as MatchesEntryRouteImport } from './routes/matches/entry/route'
 import { Route as MatchesCreateRouteImport } from './routes/matches/create/route'
 import { Route as MatchesMatchIdRecordRouteImport } from './routes/matches/$matchId/record/route'
@@ -43,6 +44,12 @@ const UsersCreateRouteRoute = UsersCreateRouteImport.update({
 const TeamsCreateRouteRoute = TeamsCreateRouteImport.update({
   id: '/teams/create',
   path: '/teams/create',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const TeamsTeamIdRouteRoute = TeamsTeamIdRouteImport.update({
+  id: '/teams/$teamId',
+  path: '/teams/$teamId',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -103,6 +110,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchesEntryRouteImport
       parentRoute: typeof rootRoute
     }
+    '/teams/$teamId': {
+      id: '/teams/$teamId'
+      path: '/teams/$teamId'
+      fullPath: '/teams/$teamId'
+      preLoaderRoute: typeof TeamsTeamIdRouteImport
+      parentRoute: typeof rootRoute
+    }
     '/teams/create': {
       id: '/teams/create'
       path: '/teams/create'
@@ -141,6 +155,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRouteRoute
   '/matches/create': typeof MatchesCreateRouteRoute
   '/matches/entry': typeof MatchesEntryRouteRoute
+  '/teams/$teamId': typeof TeamsTeamIdRouteRoute
   '/teams/create': typeof TeamsCreateRouteRoute
   '/users/create': typeof UsersCreateRouteRoute
   '/matches/$matchId/record': typeof MatchesMatchIdRecordRouteRoute
@@ -152,6 +167,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRouteRoute
   '/matches/create': typeof MatchesCreateRouteRoute
   '/matches/entry': typeof MatchesEntryRouteRoute
+  '/teams/$teamId': typeof TeamsTeamIdRouteRoute
   '/teams/create': typeof TeamsCreateRouteRoute
   '/users/create': typeof UsersCreateRouteRoute
   '/matches/$matchId/record': typeof MatchesMatchIdRecordRouteRoute
@@ -164,6 +180,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRouteRoute
   '/matches/create': typeof MatchesCreateRouteRoute
   '/matches/entry': typeof MatchesEntryRouteRoute
+  '/teams/$teamId': typeof TeamsTeamIdRouteRoute
   '/teams/create': typeof TeamsCreateRouteRoute
   '/users/create': typeof UsersCreateRouteRoute
   '/matches/$matchId/record': typeof MatchesMatchIdRecordRouteRoute
@@ -177,6 +194,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/matches/create'
     | '/matches/entry'
+    | '/teams/$teamId'
     | '/teams/create'
     | '/users/create'
     | '/matches/$matchId/record'
@@ -187,6 +205,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/matches/create'
     | '/matches/entry'
+    | '/teams/$teamId'
     | '/teams/create'
     | '/users/create'
     | '/matches/$matchId/record'
@@ -197,6 +216,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/matches/create'
     | '/matches/entry'
+    | '/teams/$teamId'
     | '/teams/create'
     | '/users/create'
     | '/matches/$matchId/record'
@@ -209,6 +229,7 @@ export interface RootRouteChildren {
   LoginRouteRoute: typeof LoginRouteRoute
   MatchesCreateRouteRoute: typeof MatchesCreateRouteRoute
   MatchesEntryRouteRoute: typeof MatchesEntryRouteRoute
+  TeamsTeamIdRouteRoute: typeof TeamsTeamIdRouteRoute
   TeamsCreateRouteRoute: typeof TeamsCreateRouteRoute
   UsersCreateRouteRoute: typeof UsersCreateRouteRoute
   MatchesMatchIdRecordRouteRoute: typeof MatchesMatchIdRecordRouteRoute
@@ -220,6 +241,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRouteRoute: LoginRouteRoute,
   MatchesCreateRouteRoute: MatchesCreateRouteRoute,
   MatchesEntryRouteRoute: MatchesEntryRouteRoute,
+  TeamsTeamIdRouteRoute: TeamsTeamIdRouteRoute,
   TeamsCreateRouteRoute: TeamsCreateRouteRoute,
   UsersCreateRouteRoute: UsersCreateRouteRoute,
   MatchesMatchIdRecordRouteRoute: MatchesMatchIdRecordRouteRoute,
@@ -240,6 +262,7 @@ export const routeTree = rootRoute
         "/login",
         "/matches/create",
         "/matches/entry",
+        "/teams/$teamId",
         "/teams/create",
         "/users/create",
         "/matches/$matchId/record",
@@ -257,6 +280,9 @@ export const routeTree = rootRoute
     },
     "/matches/entry": {
       "filePath": "matches/entry/route.tsx"
+    },
+    "/teams/$teamId": {
+      "filePath": "teams/$teamId/route.tsx"
     },
     "/teams/create": {
       "filePath": "teams/create/route.tsx"

--- a/src/routes/teams/$teamId/-components/NoticeBoard.css.ts
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.css.ts
@@ -1,0 +1,105 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  borderRadius: 8,
+  padding: 20,
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: 24,
+  height: 34,
+});
+
+export const title = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.5,
+  color: lightThemeVars.color.black,
+  fontSize: 20,
+  fontWeight: 600,
+});
+
+export const moreSection = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 16,
+  color: lightThemeVars.color.gray[500],
+});
+
+export const moreText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.3,
+  fontSize: 12,
+  fontWeight: 500,
+});
+
+export const noticeList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 30,
+  width: '100%',
+  height: 120,
+});
+
+export const noticeItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  height: 20,
+});
+
+export const noticeContent = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+});
+
+export const bullet = style({
+  borderRadius: '50%',
+  backgroundColor: lightThemeVars.color.black,
+  width: 4,
+  height: 4,
+});
+
+export const noticeTitle = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.black,
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const noticeInfo = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: 180,
+});
+
+export const authorContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 60,
+});
+
+export const authorText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const dateText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+});

--- a/src/routes/teams/$teamId/-components/NoticeBoard.css.ts
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.css.ts
@@ -27,7 +27,6 @@ export const title = style({
 export const moreSection = style({
   display: 'flex',
   alignItems: 'center',
-  gap: 16,
   color: lightThemeVars.color.gray[500],
 });
 
@@ -36,6 +35,10 @@ export const moreText = style({
   letterSpacing: -0.3,
   fontSize: 12,
   fontWeight: 500,
+});
+
+export const chevronIcon = style({
+  width: 16,
 });
 
 export const noticeList = style({

--- a/src/routes/teams/$teamId/-components/NoticeBoard.css.ts
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.css.ts
@@ -2,9 +2,10 @@ import { lightThemeVars } from '@/styles/theme.css';
 
 import { style } from '@vanilla-extract/css';
 
-export const container = style({
+export const rootContainer = style({
   borderRadius: 8,
   padding: 20,
+  paddingRight: 51,
 });
 
 export const header = style({

--- a/src/routes/teams/$teamId/-components/NoticeBoard.tsx
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.tsx
@@ -35,7 +35,7 @@ const NoticeItem = ({ notice }: NoticeItemProps) => {
 
 export const NoticeBoard = ({ notices }: NoticeBoardProps) => {
   return (
-    <div className={styles.container}>
+    <div className={styles.rootContainer}>
       <div className={styles.header}>
         <h2 className={styles.title}>공지사항</h2>
         <div className={styles.moreSection}>

--- a/src/routes/teams/$teamId/-components/NoticeBoard.tsx
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.tsx
@@ -1,0 +1,81 @@
+import * as styles from './NoticeBoard.css';
+
+// 커스텀 아이콘 컴포넌트
+const ChevronRightIcon = () => (
+  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <path
+      d='M9 18L15 12L9 6'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+interface Notice {
+  title: string;
+  author: string;
+  date: string;
+}
+
+const notices: Notice[] = [
+  {
+    title: '신입 선수 모집 안내 (2025년 봄 시즌)',
+    author: '홍명보',
+    date: '2025-04-12',
+  },
+  {
+    title: '주말 정기 연습 일정 변경 안내 – 장소 및 시간을 꼭 확인해주세요!',
+    author: '홍명보',
+    date: '2025-03-27',
+  },
+  {
+    title: '우리 동네 대표로 출전! 지역 친선 경기 참가자 모집합니다',
+    author: '홍명보',
+    date: '2025-03-24',
+  },
+];
+
+interface NoticeItemProps {
+  notice: Notice;
+}
+
+const NoticeItem = ({ notice }: NoticeItemProps) => {
+  return (
+    <div className={styles.noticeItem}>
+      <div className={styles.noticeContent}>
+        <div className={styles.bullet}></div>
+        <span className={styles.noticeTitle}>{notice.title}</span>
+      </div>
+      <div className={styles.noticeInfo}>
+        <div className={styles.authorContainer}>
+          <span className={styles.authorText}>{notice.author}</span>
+        </div>
+        <span className={styles.dateText}>{notice.date}</span>
+      </div>
+    </div>
+  );
+};
+
+export const NoticeBoard = () => {
+  return (
+    <div className={styles.container}>
+      {/* 헤더 */}
+      <div className={styles.header}>
+        <h2 className={styles.title}>공지사항</h2>
+        <div className={styles.moreSection}>
+          <span className={styles.moreText}>자세히 보기</span>
+          <ChevronRightIcon />
+        </div>
+      </div>
+
+      {/* 공지사항 목록 */}
+      <div className={styles.noticeList}>
+        {notices.map((notice, index) => (
+          <NoticeItem key={index} notice={notice} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/routes/teams/$teamId/-components/NoticeBoard.tsx
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.tsx
@@ -1,16 +1,30 @@
 import { ChevronRightIcon } from '@/assets/icons';
+import type { Notice } from '@/routes/teams/$teamId/-temp-server-types';
 
 import * as styles from './NoticeBoard.css';
-
-interface Notice {
-  title: string;
-  author: string;
-  date: string;
-}
 
 interface NoticeBoardProps {
   notices: Notice[];
 }
+
+export const NoticeBoard = ({ notices }: NoticeBoardProps) => {
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>공지사항</h2>
+        <div className={styles.moreSection}>
+          <span className={styles.moreText}>자세히 보기</span>
+          <ChevronRightIcon className={styles.chevronIcon} />
+        </div>
+      </div>
+      <div className={styles.noticeList}>
+        {notices.map((notice, index) => (
+          <NoticeItem key={index} notice={notice} />
+        ))}
+      </div>
+    </div>
+  );
+};
 
 interface NoticeItemProps {
   notice: Notice;
@@ -28,25 +42,6 @@ const NoticeItem = ({ notice }: NoticeItemProps) => {
           <span className={styles.authorText}>{notice.author}</span>
         </div>
         <span className={styles.dateText}>{notice.date}</span>
-      </div>
-    </div>
-  );
-};
-
-export const NoticeBoard = ({ notices }: NoticeBoardProps) => {
-  return (
-    <div className={styles.rootContainer}>
-      <div className={styles.header}>
-        <h2 className={styles.title}>공지사항</h2>
-        <div className={styles.moreSection}>
-          <span className={styles.moreText}>자세히 보기</span>
-          <ChevronRightIcon className={styles.chevronIcon} />
-        </div>
-      </div>
-      <div className={styles.noticeList}>
-        {notices.map((notice, index) => (
-          <NoticeItem key={index} notice={notice} />
-        ))}
       </div>
     </div>
   );

--- a/src/routes/teams/$teamId/-components/NoticeBoard.tsx
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.tsx
@@ -19,23 +19,9 @@ interface Notice {
   date: string;
 }
 
-const notices: Notice[] = [
-  {
-    title: '신입 선수 모집 안내 (2025년 봄 시즌)',
-    author: '홍명보',
-    date: '2025-04-12',
-  },
-  {
-    title: '주말 정기 연습 일정 변경 안내 – 장소 및 시간을 꼭 확인해주세요!',
-    author: '홍명보',
-    date: '2025-03-27',
-  },
-  {
-    title: '우리 동네 대표로 출전! 지역 친선 경기 참가자 모집합니다',
-    author: '홍명보',
-    date: '2025-03-24',
-  },
-];
+interface NoticeBoardProps {
+  notices: Notice[];
+}
 
 interface NoticeItemProps {
   notice: Notice;
@@ -58,10 +44,9 @@ const NoticeItem = ({ notice }: NoticeItemProps) => {
   );
 };
 
-export const NoticeBoard = () => {
+export const NoticeBoard = ({ notices }: NoticeBoardProps) => {
   return (
     <div className={styles.container}>
-      {/* 헤더 */}
       <div className={styles.header}>
         <h2 className={styles.title}>공지사항</h2>
         <div className={styles.moreSection}>
@@ -69,8 +54,6 @@ export const NoticeBoard = () => {
           <ChevronRightIcon />
         </div>
       </div>
-
-      {/* 공지사항 목록 */}
       <div className={styles.noticeList}>
         {notices.map((notice, index) => (
           <NoticeItem key={index} notice={notice} />

--- a/src/routes/teams/$teamId/-components/NoticeBoard.tsx
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.tsx
@@ -1,17 +1,6 @@
-import * as styles from './NoticeBoard.css';
+import { ChevronRightIcon } from '@/assets/icons';
 
-// 커스텀 아이콘 컴포넌트
-const ChevronRightIcon = () => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
-    <path
-      d='M9 18L15 12L9 6'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
+import * as styles from './NoticeBoard.css';
 
 interface Notice {
   title: string;

--- a/src/routes/teams/$teamId/-components/NoticeBoard.tsx
+++ b/src/routes/teams/$teamId/-components/NoticeBoard.tsx
@@ -40,7 +40,7 @@ export const NoticeBoard = ({ notices }: NoticeBoardProps) => {
         <h2 className={styles.title}>공지사항</h2>
         <div className={styles.moreSection}>
           <span className={styles.moreText}>자세히 보기</span>
-          <ChevronRightIcon />
+          <ChevronRightIcon className={styles.chevronIcon} />
         </div>
       </div>
       <div className={styles.noticeList}>

--- a/src/routes/teams/$teamId/-components/RecentRecords.css.ts
+++ b/src/routes/teams/$teamId/-components/RecentRecords.css.ts
@@ -1,0 +1,145 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  borderRadius: 8,
+  padding: 20,
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: 24,
+  height: 34,
+});
+
+export const title = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.5,
+  color: lightThemeVars.color.black,
+  fontSize: 20,
+  fontWeight: 600,
+});
+
+export const moreSection = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 16,
+  color: lightThemeVars.color.gray[500],
+});
+
+export const moreText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.3,
+  fontSize: 12,
+  fontWeight: 500,
+});
+
+export const matchGrid = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 80,
+  overflowX: 'auto',
+});
+
+export const matchCard = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  gap: 12,
+  width: 192,
+});
+
+export const matchInfo = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+export const matchDate = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.3,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 12,
+  fontWeight: 500,
+});
+
+export const matchDuration = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.3,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 12,
+  fontWeight: 500,
+});
+
+export const matchResult = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  width: '100%',
+});
+
+export const teamRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+export const teamInfo = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+});
+
+export const teamLogo = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px solid ${lightThemeVars.color.gray[500]}`,
+  borderRadius: '50%',
+  backgroundColor: lightThemeVars.color.white.main,
+  width: 44,
+  height: 44,
+});
+
+export const logoImage = style({
+  width: 28,
+  height: 32,
+});
+
+export const teamNameWinner = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.black,
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const teamNameLoser = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const scoreWinner = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.black,
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const scoreLoser = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 16,
+  fontWeight: 600,
+});

--- a/src/routes/teams/$teamId/-components/RecentRecords.css.ts
+++ b/src/routes/teams/$teamId/-components/RecentRecords.css.ts
@@ -27,7 +27,6 @@ export const title = style({
 export const moreSection = style({
   display: 'flex',
   alignItems: 'center',
-  gap: 16,
   color: lightThemeVars.color.gray[500],
 });
 
@@ -36,6 +35,10 @@ export const moreText = style({
   letterSpacing: -0.3,
   fontSize: 12,
   fontWeight: 500,
+});
+
+export const chevronIcon = style({
+  width: 16,
 });
 
 export const matchGrid = style({

--- a/src/routes/teams/$teamId/-components/RecentRecords.css.ts
+++ b/src/routes/teams/$teamId/-components/RecentRecords.css.ts
@@ -2,9 +2,10 @@ import { lightThemeVars } from '@/styles/theme.css';
 
 import { style } from '@vanilla-extract/css';
 
-export const container = style({
+export const rootContainer = style({
   borderRadius: 8,
   padding: 20,
+  paddingRight: 51,
 });
 
 export const header = style({

--- a/src/routes/teams/$teamId/-components/RecentRecords.tsx
+++ b/src/routes/teams/$teamId/-components/RecentRecords.tsx
@@ -1,0 +1,160 @@
+import * as styles from './RecentRecords.css';
+
+// 커스텀 아이콘 컴포넌트
+const ChevronRightIcon = () => (
+  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <path
+      d='M9 18L15 12L9 6'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+interface MatchResult {
+  date: string;
+  duration: string;
+  homeTeam: {
+    name: string;
+    logo: string;
+    score: number;
+  };
+  awayTeam: {
+    name: string;
+    logo: string;
+    score: number;
+  };
+}
+
+const matchResults: MatchResult[] = [
+  {
+    date: '2025-04-23',
+    duration: '96"',
+    homeTeam: {
+      name: 'FC 서울',
+      logo: '/api/placeholder/44/44',
+      score: 1,
+    },
+    awayTeam: {
+      name: 'FC 수원',
+      logo: '/api/placeholder/44/44',
+      score: 2,
+    },
+  },
+  {
+    date: '2025-04-01',
+    duration: '90"',
+    homeTeam: {
+      name: 'FC 서울',
+      logo: '/api/placeholder/44/44',
+      score: 1,
+    },
+    awayTeam: {
+      name: 'FC 수원',
+      logo: '/api/placeholder/44/44',
+      score: 1,
+    },
+  },
+  {
+    date: '2025-03-21',
+    duration: '94"',
+    homeTeam: {
+      name: 'FC 서울',
+      logo: '/api/placeholder/44/44',
+      score: 3,
+    },
+    awayTeam: {
+      name: 'FC 수원',
+      logo: '/api/placeholder/44/44',
+      score: 0,
+    },
+  },
+];
+
+interface MatchResultCardProps {
+  match: MatchResult;
+}
+
+const MatchResultCard = ({ match }: MatchResultCardProps) => {
+  const homeWon = match.homeTeam.score > match.awayTeam.score;
+  const awayWon = match.awayTeam.score > match.homeTeam.score;
+
+  return (
+    <div className={styles.matchCard}>
+      {/* 날짜 및 경기 시간 */}
+      <div className={styles.matchInfo}>
+        <span className={styles.matchDate}>{match.date}</span>
+        <span className={styles.matchDuration}>{match.duration}</span>
+      </div>
+
+      {/* 경기 결과 */}
+      <div className={styles.matchResult}>
+        {/* 홈팀 */}
+        <div className={styles.teamRow}>
+          <div className={styles.teamInfo}>
+            <div className={styles.teamLogo}>
+              <img
+                src={match.homeTeam.logo}
+                alt={`${match.homeTeam.name} logo`}
+                className={styles.logoImage}
+              />
+            </div>
+            <span
+              className={homeWon ? styles.teamNameWinner : styles.teamNameLoser}
+            >
+              {match.homeTeam.name}
+            </span>
+          </div>
+          <span className={homeWon ? styles.scoreWinner : styles.scoreLoser}>
+            {match.homeTeam.score}
+          </span>
+        </div>
+
+        {/* 원정팀 */}
+        <div className={styles.teamRow}>
+          <div className={styles.teamInfo}>
+            <div className={styles.teamLogo}>
+              <img
+                src={match.awayTeam.logo}
+                alt={`${match.awayTeam.name} logo`}
+                className={styles.logoImage}
+              />
+            </div>
+            <span
+              className={awayWon ? styles.teamNameWinner : styles.teamNameLoser}
+            >
+              {match.awayTeam.name}
+            </span>
+          </div>
+          <span className={awayWon ? styles.scoreWinner : styles.scoreLoser}>
+            {match.awayTeam.score}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const RecentRecords = () => {
+  return (
+    <div className={styles.container}>
+      {/* 헤더 */}
+      <div className={styles.header}>
+        <h2 className={styles.title}>최근 기록</h2>
+        <div className={styles.moreSection}>
+          <span className={styles.moreText}>자세히 보기</span>
+          <ChevronRightIcon />
+        </div>
+      </div>
+
+      {/* 경기 결과 */}
+      <div className={styles.matchGrid}>
+        {matchResults.map((match, index) => (
+          <MatchResultCard key={index} match={match} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/routes/teams/$teamId/-components/RecentRecords.tsx
+++ b/src/routes/teams/$teamId/-components/RecentRecords.tsx
@@ -21,6 +21,28 @@ interface RecentRecordsProps {
   matchResults: MatchResult[];
 }
 
+export const RecentRecords = ({ matchResults }: RecentRecordsProps) => {
+  return (
+    <div className={styles.rootContainer}>
+      {/* 헤더 */}
+      <div className={styles.header}>
+        <h2 className={styles.title}>최근 기록</h2>
+        <div className={styles.moreSection}>
+          <span className={styles.moreText}>자세히 보기</span>
+          <ChevronRightIcon />
+        </div>
+      </div>
+
+      {/* 경기 결과 */}
+      <div className={styles.matchGrid}>
+        {matchResults.map((match, index) => (
+          <MatchResultCard key={index} match={match} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
 interface MatchResultCardProps {
   match: MatchResult;
 }
@@ -80,28 +102,6 @@ const MatchResultCard = ({ match }: MatchResultCardProps) => {
             {match.awayTeam.score}
           </span>
         </div>
-      </div>
-    </div>
-  );
-};
-
-export const RecentRecords = ({ matchResults }: RecentRecordsProps) => {
-  return (
-    <div className={styles.container}>
-      {/* 헤더 */}
-      <div className={styles.header}>
-        <h2 className={styles.title}>최근 기록</h2>
-        <div className={styles.moreSection}>
-          <span className={styles.moreText}>자세히 보기</span>
-          <ChevronRightIcon />
-        </div>
-      </div>
-
-      {/* 경기 결과 */}
-      <div className={styles.matchGrid}>
-        {matchResults.map((match, index) => (
-          <MatchResultCard key={index} match={match} />
-        ))}
       </div>
     </div>
   );

--- a/src/routes/teams/$teamId/-components/RecentRecords.tsx
+++ b/src/routes/teams/$teamId/-components/RecentRecords.tsx
@@ -1,17 +1,6 @@
-import * as styles from './RecentRecords.css';
+import { ChevronRightIcon } from '@/assets/icons';
 
-// 커스텀 아이콘 컴포넌트
-const ChevronRightIcon = () => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
-    <path
-      d='M9 18L15 12L9 6'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
+import * as styles from './RecentRecords.css';
 
 interface MatchResult {
   date: string;

--- a/src/routes/teams/$teamId/-components/RecentRecords.tsx
+++ b/src/routes/teams/$teamId/-components/RecentRecords.tsx
@@ -1,21 +1,8 @@
 import { ChevronRightIcon } from '@/assets/icons';
+import DefaultTeamLogo from '@/assets/images/teams/default-team-logo.svg?react';
+import type { MatchResult } from '@/routes/teams/$teamId/-temp-server-types';
 
 import * as styles from './RecentRecords.css';
-
-interface MatchResult {
-  date: string;
-  duration: string;
-  homeTeam: {
-    name: string;
-    logo: string;
-    score: number;
-  };
-  awayTeam: {
-    name: string;
-    logo: string;
-    score: number;
-  };
-}
 
 interface RecentRecordsProps {
   matchResults: MatchResult[];
@@ -64,11 +51,18 @@ const MatchResultCard = ({ match }: MatchResultCardProps) => {
         <div className={styles.teamRow}>
           <div className={styles.teamInfo}>
             <div className={styles.teamLogo}>
-              <img
-                src={match.homeTeam.logo}
-                alt={`${match.homeTeam.name} logo`}
-                className={styles.logoImage}
-              />
+              {match.homeTeam.logo ? (
+                <img
+                  src={match.homeTeam.logo}
+                  alt=''
+                  className={styles.logoImage}
+                />
+              ) : (
+                <DefaultTeamLogo
+                  className={styles.logoImage}
+                  style={{ color: match.homeTeam.uniformColor.top }}
+                />
+              )}
             </div>
             <span
               className={homeWon ? styles.teamNameWinner : styles.teamNameLoser}
@@ -85,11 +79,18 @@ const MatchResultCard = ({ match }: MatchResultCardProps) => {
         <div className={styles.teamRow}>
           <div className={styles.teamInfo}>
             <div className={styles.teamLogo}>
-              <img
-                src={match.awayTeam.logo}
-                alt={`${match.awayTeam.name} logo`}
-                className={styles.logoImage}
-              />
+              {match.awayTeam.logo ? (
+                <img
+                  src={match.awayTeam.logo}
+                  alt=''
+                  className={styles.logoImage}
+                />
+              ) : (
+                <DefaultTeamLogo
+                  className={styles.logoImage}
+                  style={{ color: match.awayTeam.uniformColor.top }}
+                />
+              )}
             </div>
             <span
               className={awayWon ? styles.teamNameWinner : styles.teamNameLoser}

--- a/src/routes/teams/$teamId/-components/RecentRecords.tsx
+++ b/src/routes/teams/$teamId/-components/RecentRecords.tsx
@@ -29,10 +29,9 @@ export const RecentRecords = ({ matchResults }: RecentRecordsProps) => {
         <h2 className={styles.title}>최근 기록</h2>
         <div className={styles.moreSection}>
           <span className={styles.moreText}>자세히 보기</span>
-          <ChevronRightIcon />
+          <ChevronRightIcon className={styles.chevronIcon} />
         </div>
       </div>
-
       {/* 경기 결과 */}
       <div className={styles.matchGrid}>
         {matchResults.map((match, index) => (

--- a/src/routes/teams/$teamId/-components/RecentRecords.tsx
+++ b/src/routes/teams/$teamId/-components/RecentRecords.tsx
@@ -28,50 +28,9 @@ interface MatchResult {
   };
 }
 
-const matchResults: MatchResult[] = [
-  {
-    date: '2025-04-23',
-    duration: '96"',
-    homeTeam: {
-      name: 'FC 서울',
-      logo: '/api/placeholder/44/44',
-      score: 1,
-    },
-    awayTeam: {
-      name: 'FC 수원',
-      logo: '/api/placeholder/44/44',
-      score: 2,
-    },
-  },
-  {
-    date: '2025-04-01',
-    duration: '90"',
-    homeTeam: {
-      name: 'FC 서울',
-      logo: '/api/placeholder/44/44',
-      score: 1,
-    },
-    awayTeam: {
-      name: 'FC 수원',
-      logo: '/api/placeholder/44/44',
-      score: 1,
-    },
-  },
-  {
-    date: '2025-03-21',
-    duration: '94"',
-    homeTeam: {
-      name: 'FC 서울',
-      logo: '/api/placeholder/44/44',
-      score: 3,
-    },
-    awayTeam: {
-      name: 'FC 수원',
-      logo: '/api/placeholder/44/44',
-      score: 0,
-    },
-  },
-];
+interface RecentRecordsProps {
+  matchResults: MatchResult[];
+}
 
 interface MatchResultCardProps {
   match: MatchResult;
@@ -137,7 +96,7 @@ const MatchResultCard = ({ match }: MatchResultCardProps) => {
   );
 };
 
-export const RecentRecords = () => {
+export const RecentRecords = ({ matchResults }: RecentRecordsProps) => {
   return (
     <div className={styles.container}>
       {/* 헤더 */}

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.css.ts
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.css.ts
@@ -26,7 +26,6 @@ export const title = style({
 export const moreSection = style({
   display: 'flex',
   alignItems: 'center',
-  gap: 16,
   color: lightThemeVars.color.gray[500],
 });
 
@@ -35,6 +34,10 @@ export const moreText = style({
   letterSpacing: -0.3,
   fontSize: 12,
   fontWeight: 500,
+});
+
+export const chevronIcon = style({
+  width: 16,
 });
 
 export const calendarContainer = style({

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.css.ts
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.css.ts
@@ -1,0 +1,172 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  borderRadius: 8,
+  padding: 20,
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: 32,
+  width: '100%',
+});
+
+export const title = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.5,
+  color: lightThemeVars.color.black,
+  fontSize: 20,
+  fontWeight: 600,
+});
+
+export const moreSection = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 16,
+  color: lightThemeVars.color.gray[500],
+});
+
+export const moreText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.3,
+  fontSize: 12,
+  fontWeight: 500,
+});
+
+export const calendarContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+});
+
+export const monthNavigation = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 105,
+  marginBottom: 30,
+  color: lightThemeVars.color.black,
+});
+
+export const monthText = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.6,
+  color: lightThemeVars.color.black,
+  fontSize: 24,
+  fontWeight: 400,
+});
+
+export const calendarGrid = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+});
+
+export const weekHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+});
+
+export const weekDayContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 54,
+  height: 54,
+});
+
+export const weekDayText = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.black,
+  fontSize: 16,
+  fontWeight: 400,
+});
+
+export const weekRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+});
+
+export const dayContainer = style({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 54,
+  height: 54,
+});
+
+export const dayContent = style({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  gap: 2,
+  height: 30,
+});
+
+export const selectedDayContent = style({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '50%',
+  backgroundColor: lightThemeVars.color.primary[700],
+  width: 54,
+  height: 54,
+});
+
+export const eventDot = style({
+  borderRadius: '50%',
+  backgroundColor: lightThemeVars.color.primary[700],
+  width: 6,
+  height: 6,
+});
+
+export const selectedEventDot = style({
+  position: 'absolute',
+  top: 8,
+  borderRadius: '50%',
+  backgroundColor: lightThemeVars.color.white.main,
+  width: 6,
+  height: 6,
+});
+
+export const selectedDayText = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.white.main,
+  fontSize: 16,
+  fontWeight: 400,
+});
+
+export const currentMonthDayText = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 16,
+  fontWeight: 400,
+});
+
+export const otherMonthDayText = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.gray[300],
+  fontSize: 16,
+  fontWeight: 400,
+});

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
@@ -1,13 +1,7 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@/assets/icons';
+import type { CalendarDay } from '@/routes/teams/$teamId/-temp-server-types';
 
 import * as styles from './ScheduleCalendar.css';
-
-interface CalendarDay {
-  day: number;
-  isCurrentMonth: boolean;
-  isSelected?: boolean;
-  hasEvent?: boolean;
-}
 
 interface ScheduleCalendarProps {
   currentMonth: string;

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
@@ -1,28 +1,6 @@
+import { ChevronLeftIcon, ChevronRightIcon } from '@/assets/icons';
+
 import * as styles from './ScheduleCalendar.css';
-
-const ChevronLeftIcon = () => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
-    <path
-      d='M15 18L9 12L15 6'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
-
-const ChevronRightIcon = () => (
-  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
-    <path
-      d='M9 18L15 12L9 6'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
 
 interface CalendarDay {
   day: number;

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
@@ -1,0 +1,164 @@
+import * as styles from './ScheduleCalendar.css';
+
+// 커스텀 아이콘 컴포넌트들
+const ChevronLeftIcon = () => (
+  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <path
+      d='M15 18L9 12L15 6'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+const ChevronRightIcon = () => (
+  <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
+    <path
+      d='M9 18L15 12L9 6'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+interface CalendarDayProps {
+  day: number;
+  isCurrentMonth: boolean;
+  isSelected?: boolean;
+  hasEvent?: boolean;
+}
+
+const CalendarDay = ({
+  day,
+  isCurrentMonth,
+  isSelected,
+  hasEvent,
+}: CalendarDayProps) => {
+  return (
+    <div className={styles.dayContainer}>
+      <div
+        className={isSelected ? styles.selectedDayContent : styles.dayContent}
+      >
+        {hasEvent && !isSelected && <div className={styles.eventDot}></div>}
+        {hasEvent && isSelected && (
+          <div className={styles.selectedEventDot}></div>
+        )}
+        <span
+          className={
+            isSelected
+              ? styles.selectedDayText
+              : isCurrentMonth
+                ? styles.currentMonthDayText
+                : styles.otherMonthDayText
+          }
+        >
+          {day}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export const ScheduleCalendar = () => {
+  const currentMonth = '2025-04';
+  const daysOfWeek = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+
+  // 2025년 4월 캘린더 데이터
+  const calendarDays = [
+    // 이전 달 날짜들 (3월 31일)
+    { day: 29, isCurrentMonth: false },
+    { day: 30, isCurrentMonth: false },
+    { day: 31, isCurrentMonth: false },
+    // 현재 달 날짜들
+    { day: 1, isCurrentMonth: true },
+    { day: 2, isCurrentMonth: true },
+    { day: 3, isCurrentMonth: true },
+    { day: 4, isCurrentMonth: true, hasEvent: true },
+    { day: 5, isCurrentMonth: true },
+    { day: 6, isCurrentMonth: true },
+    { day: 7, isCurrentMonth: true },
+    { day: 8, isCurrentMonth: true },
+    { day: 9, isCurrentMonth: true },
+    { day: 10, isCurrentMonth: true },
+    { day: 11, isCurrentMonth: true },
+    { day: 12, isCurrentMonth: true },
+    { day: 13, isCurrentMonth: true, hasEvent: true },
+    { day: 14, isCurrentMonth: true },
+    { day: 15, isCurrentMonth: true },
+    { day: 16, isCurrentMonth: true },
+    { day: 17, isCurrentMonth: true, isSelected: true, hasEvent: true },
+    { day: 18, isCurrentMonth: true },
+    { day: 19, isCurrentMonth: true },
+    { day: 20, isCurrentMonth: true, hasEvent: true },
+    { day: 21, isCurrentMonth: true },
+    { day: 22, isCurrentMonth: true, hasEvent: true },
+    { day: 23, isCurrentMonth: true },
+    { day: 24, isCurrentMonth: true },
+    { day: 25, isCurrentMonth: true },
+    { day: 26, isCurrentMonth: true },
+    { day: 27, isCurrentMonth: true },
+    { day: 28, isCurrentMonth: true },
+    { day: 29, isCurrentMonth: true },
+    { day: 30, isCurrentMonth: true },
+    // 다음 달 날짜들 (5월 1-3일)
+    { day: 1, isCurrentMonth: false },
+    { day: 2, isCurrentMonth: false },
+    { day: 3, isCurrentMonth: false },
+  ];
+
+  return (
+    <div className={styles.container}>
+      {/* 헤더 */}
+      <div className={styles.header}>
+        <h2 className={styles.title}>일정</h2>
+        <div className={styles.moreSection}>
+          <span className={styles.moreText}>자세히 보기</span>
+          <ChevronRightIcon />
+        </div>
+      </div>
+
+      {/* 캘린더 */}
+      <div className={styles.calendarContainer}>
+        {/* 월 네비게이션 */}
+        <div className={styles.monthNavigation}>
+          <ChevronLeftIcon />
+          <span className={styles.monthText}>{currentMonth}</span>
+          <ChevronRightIcon />
+        </div>
+
+        {/* 캘린더 그리드 */}
+        <div className={styles.calendarGrid}>
+          {/* 요일 헤더 */}
+          <div className={styles.weekHeader}>
+            {daysOfWeek.map(day => (
+              <div key={day} className={styles.weekDayContainer}>
+                <span className={styles.weekDayText}>{day}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* 캘린더 날짜들 */}
+          {Array.from({ length: 6 }, (_, weekIndex) => (
+            <div key={weekIndex} className={styles.weekRow}>
+              {calendarDays
+                .slice(weekIndex * 7, (weekIndex + 1) * 7)
+                .map((dayData, dayIndex) => (
+                  <CalendarDay
+                    key={`${weekIndex}-${dayIndex}`}
+                    day={dayData.day}
+                    isCurrentMonth={dayData.isCurrentMonth}
+                    isSelected={dayData.isSelected}
+                    hasEvent={dayData.hasEvent}
+                  />
+                ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
@@ -1,6 +1,5 @@
 import * as styles from './ScheduleCalendar.css';
 
-// 커스텀 아이콘 컴포넌트들
 const ChevronLeftIcon = () => (
   <svg width='24' height='24' viewBox='0 0 24 24' fill='none'>
     <path
@@ -24,6 +23,18 @@ const ChevronRightIcon = () => (
     />
   </svg>
 );
+
+interface CalendarDay {
+  day: number;
+  isCurrentMonth: boolean;
+  isSelected?: boolean;
+  hasEvent?: boolean;
+}
+
+interface ScheduleCalendarProps {
+  currentMonth: string;
+  calendarDays: CalendarDay[];
+}
 
 interface CalendarDayProps {
   day: number;
@@ -63,56 +74,14 @@ const CalendarDay = ({
   );
 };
 
-export const ScheduleCalendar = () => {
-  const currentMonth = '2025-04';
+export const ScheduleCalendar = ({
+  currentMonth,
+  calendarDays,
+}: ScheduleCalendarProps) => {
   const daysOfWeek = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
-
-  // 2025년 4월 캘린더 데이터
-  const calendarDays = [
-    // 이전 달 날짜들 (3월 31일)
-    { day: 29, isCurrentMonth: false },
-    { day: 30, isCurrentMonth: false },
-    { day: 31, isCurrentMonth: false },
-    // 현재 달 날짜들
-    { day: 1, isCurrentMonth: true },
-    { day: 2, isCurrentMonth: true },
-    { day: 3, isCurrentMonth: true },
-    { day: 4, isCurrentMonth: true, hasEvent: true },
-    { day: 5, isCurrentMonth: true },
-    { day: 6, isCurrentMonth: true },
-    { day: 7, isCurrentMonth: true },
-    { day: 8, isCurrentMonth: true },
-    { day: 9, isCurrentMonth: true },
-    { day: 10, isCurrentMonth: true },
-    { day: 11, isCurrentMonth: true },
-    { day: 12, isCurrentMonth: true },
-    { day: 13, isCurrentMonth: true, hasEvent: true },
-    { day: 14, isCurrentMonth: true },
-    { day: 15, isCurrentMonth: true },
-    { day: 16, isCurrentMonth: true },
-    { day: 17, isCurrentMonth: true, isSelected: true, hasEvent: true },
-    { day: 18, isCurrentMonth: true },
-    { day: 19, isCurrentMonth: true },
-    { day: 20, isCurrentMonth: true, hasEvent: true },
-    { day: 21, isCurrentMonth: true },
-    { day: 22, isCurrentMonth: true, hasEvent: true },
-    { day: 23, isCurrentMonth: true },
-    { day: 24, isCurrentMonth: true },
-    { day: 25, isCurrentMonth: true },
-    { day: 26, isCurrentMonth: true },
-    { day: 27, isCurrentMonth: true },
-    { day: 28, isCurrentMonth: true },
-    { day: 29, isCurrentMonth: true },
-    { day: 30, isCurrentMonth: true },
-    // 다음 달 날짜들 (5월 1-3일)
-    { day: 1, isCurrentMonth: false },
-    { day: 2, isCurrentMonth: false },
-    { day: 3, isCurrentMonth: false },
-  ];
 
   return (
     <div className={styles.container}>
-      {/* 헤더 */}
       <div className={styles.header}>
         <h2 className={styles.title}>일정</h2>
         <div className={styles.moreSection}>
@@ -121,18 +90,14 @@ export const ScheduleCalendar = () => {
         </div>
       </div>
 
-      {/* 캘린더 */}
       <div className={styles.calendarContainer}>
-        {/* 월 네비게이션 */}
         <div className={styles.monthNavigation}>
           <ChevronLeftIcon />
           <span className={styles.monthText}>{currentMonth}</span>
           <ChevronRightIcon />
         </div>
 
-        {/* 캘린더 그리드 */}
         <div className={styles.calendarGrid}>
-          {/* 요일 헤더 */}
           <div className={styles.weekHeader}>
             {daysOfWeek.map(day => (
               <div key={day} className={styles.weekDayContainer}>
@@ -141,7 +106,6 @@ export const ScheduleCalendar = () => {
             ))}
           </div>
 
-          {/* 캘린더 날짜들 */}
           {Array.from({ length: 6 }, (_, weekIndex) => (
             <div key={weekIndex} className={styles.weekRow}>
               {calendarDays

--- a/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/-components/ScheduleCalendar.tsx
@@ -64,7 +64,7 @@ export const ScheduleCalendar = ({
         <h2 className={styles.title}>일정</h2>
         <div className={styles.moreSection}>
           <span className={styles.moreText}>자세히 보기</span>
-          <ChevronRightIcon />
+          <ChevronRightIcon className={styles.chevronIcon} />
         </div>
       </div>
 

--- a/src/routes/teams/$teamId/-components/TeamHeader.css.ts
+++ b/src/routes/teams/$teamId/-components/TeamHeader.css.ts
@@ -1,6 +1,8 @@
 import { lightThemeVars } from '@/styles/theme.css';
 
-import { style } from '@vanilla-extract/css';
+import { createVar, style } from '@vanilla-extract/css';
+
+export const sockColorVar = createVar();
 
 export const container = style({
   borderTopLeftRadius: 8,
@@ -34,7 +36,6 @@ export const logoContainer = style({
 
 export const logoImage = style({
   width: 64,
-  height: 76,
 });
 
 export const teamDetails = style({
@@ -86,7 +87,9 @@ export const editText = style({
 export const statsGrid = style({
   display: 'flex',
   justifyContent: 'space-between',
+  justifySelf: 'center', // NOTE: 부모 하나를 더 두고 center 주는 대신 self justify 사용
   gap: 0,
+  width: 1112,
 });
 
 export const statItem = style({
@@ -151,28 +154,33 @@ export const uniformIcon = style({
 export const jerseyIcon = style({
   position: 'absolute',
   top: 0,
+  left: 2.5,
+  width: 20,
+  color: lightThemeVars.color.primary[100],
 });
 
 export const shortsIcon = style({
   position: 'absolute',
-  top: 20,
+  top: 16,
+  left: 5,
+  color: lightThemeVars.color.primary[100],
 });
 
 export const socksContainer = style({
   position: 'absolute',
-  bottom: 0,
-  left: 6,
+  bottom: 3,
+  left: 5.5,
   display: 'flex',
-  gap: 6,
+  gap: 4,
 });
 
 export const sock = style({
-  border: `1px solid ${lightThemeVars.color.primary[300]}`,
+  border: `1.5px solid ${lightThemeVars.color.primary[100]}`,
+  backgroundColor: sockColorVar,
   width: 2,
-  height: 6,
+  height: 7,
 });
 
-// 아이콘 스타일 추가
 export const statIcon = style({
   color: lightThemeVars.color.primary[300],
 });

--- a/src/routes/teams/$teamId/-components/TeamHeader.css.ts
+++ b/src/routes/teams/$teamId/-components/TeamHeader.css.ts
@@ -5,8 +5,7 @@ import { createVar, style } from '@vanilla-extract/css';
 export const sockColorVar = createVar();
 
 export const container = style({
-  borderTopLeftRadius: 8,
-  borderTopRightRadius: 8,
+  borderRadius: 10,
   backgroundColor: lightThemeVars.color.primary[800],
 });
 

--- a/src/routes/teams/$teamId/-components/TeamHeader.css.ts
+++ b/src/routes/teams/$teamId/-components/TeamHeader.css.ts
@@ -1,0 +1,182 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  borderTopLeftRadius: 8,
+  borderTopRightRadius: 8,
+  backgroundColor: lightThemeVars.color.primary[800],
+});
+
+export const contentWrapper = style({
+  padding: '40px 40px',
+});
+
+export const teamInfoSection = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'flex-start',
+  gap: 16,
+  marginBottom: 40,
+});
+
+export const logoContainer = style({
+  display: 'flex',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px solid ${lightThemeVars.color.gray[500]}`,
+  borderRadius: '50%',
+  backgroundColor: lightThemeVars.color.white.main,
+  width: 100,
+  height: 100,
+});
+
+export const logoImage = style({
+  width: 64,
+  height: 76,
+});
+
+export const teamDetails = style({
+  flex: 1,
+  textAlign: 'left',
+});
+
+export const teamDetailsInner = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  gap: 16,
+});
+
+export const teamName = style({
+  marginBottom: 4,
+  lineHeight: 1.4,
+  letterSpacing: -0.8,
+  color: lightThemeVars.color.white.main,
+  fontSize: 32,
+  fontWeight: 600,
+});
+
+export const teamDescription = style({
+  maxWidth: 706,
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.primary[300],
+  fontSize: 16,
+  fontWeight: 500,
+});
+
+export const editSection = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  gap: 8,
+  color: lightThemeVars.color.primary[300],
+});
+
+export const editText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const statsGrid = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 0,
+});
+
+export const statItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 20,
+});
+
+export const statHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+});
+
+export const statLabel = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.primary[300],
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const statValue = style({
+  textAlign: 'center',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.white.main,
+  fontSize: 16,
+  fontWeight: 500,
+});
+
+export const uniformSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 8,
+});
+
+export const uniformLabel = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.primary[300],
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const uniformContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 8,
+});
+
+export const uniformIcon = style({
+  position: 'relative',
+  width: 24,
+  height: 40,
+});
+
+export const jerseyIcon = style({
+  position: 'absolute',
+  top: 0,
+});
+
+export const shortsIcon = style({
+  position: 'absolute',
+  top: 20,
+});
+
+export const socksContainer = style({
+  position: 'absolute',
+  bottom: 0,
+  left: 6,
+  display: 'flex',
+  gap: 6,
+});
+
+export const sock = style({
+  border: `1px solid ${lightThemeVars.color.primary[300]}`,
+  width: 2,
+  height: 6,
+});
+
+// 아이콘 스타일 추가
+export const statIcon = style({
+  color: lightThemeVars.color.primary[300],
+});
+
+export const chevronIcon = style({
+  color: lightThemeVars.color.primary[300],
+});

--- a/src/routes/teams/$teamId/-components/TeamHeader.css.ts
+++ b/src/routes/teams/$teamId/-components/TeamHeader.css.ts
@@ -73,7 +73,6 @@ export const editSection = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'flex-start',
-  gap: 8,
   color: lightThemeVars.color.primary[300],
 });
 

--- a/src/routes/teams/$teamId/-components/TeamHeader.tsx
+++ b/src/routes/teams/$teamId/-components/TeamHeader.tsx
@@ -1,24 +1,30 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+
 import {
   ArrowRightIcon,
   CrownIcon,
+  JerseyIcon,
   LoaderIcon,
   MapIcon,
+  ShortsIcon,
   UsersIcon,
 } from '@/assets/icons';
+import DefaultTeamLogo from '@/assets/images/teams/default-team-logo.svg?react';
 
 import * as styles from './TeamHeader.css';
 
 interface TeamInfo {
   name: string;
   description: string;
-  logoUrl: string;
+  logoUrl: string | null;
   leader: string;
   foundedYear: number;
   region: string;
   memberCount: number;
   uniformColors: {
-    primary: string;
-    secondary: string;
+    top: string;
+    bottom: string;
+    socks: string;
   };
 }
 
@@ -32,11 +38,16 @@ export const TeamHeader = ({ teamInfo }: TeamHeaderProps) => {
       <div className={styles.contentWrapper}>
         <div className={styles.teamInfoSection}>
           <div className={styles.logoContainer}>
-            <img
-              src={teamInfo.logoUrl}
-              alt={`${teamInfo.name} Logo`}
-              className={styles.logoImage}
-            />
+            {teamInfo.logoUrl ? (
+              <img src={teamInfo.logoUrl} alt='' className={styles.logoImage} />
+            ) : (
+              <DefaultTeamLogo
+                className={styles.logoImage}
+                style={{
+                  color: teamInfo.uniformColors.top,
+                }}
+              />
+            )}
           </div>
           <div className={styles.teamDetails}>
             <div className={styles.teamDetailsInner}>
@@ -51,7 +62,6 @@ export const TeamHeader = ({ teamInfo }: TeamHeaderProps) => {
             </div>
           </div>
         </div>
-
         <div className={styles.statsGrid}>
           <div className={styles.statItem}>
             <div className={styles.statHeader}>
@@ -85,35 +95,26 @@ export const TeamHeader = ({ teamInfo }: TeamHeaderProps) => {
             <span className={styles.uniformLabel}>유니폼</span>
             <div className={styles.uniformContainer}>
               <div className={styles.uniformIcon}>
-                <svg
-                  width='25'
-                  height='16'
-                  viewBox='0 0 25 16'
-                  fill='none'
+                <JerseyIcon
                   className={styles.jerseyIcon}
-                >
-                  <path
-                    d='M7.02694 8.90575H7.77694V6.89292L6.4598 8.41497L7.02694 8.90575ZM7.02694 15.2303H6.27694C6.27694 15.6446 6.61272 15.9803 7.02694 15.9803V15.2303ZM17.9731 15.2303V15.9803C18.3874 15.9803 18.7231 15.6446 18.7231 15.2303H17.9731ZM17.9731 8.90575L18.5403 8.41497L17.2231 6.89292V8.90575H17.9731ZM20.0256 11.2775L19.4584 11.7683C19.6009 11.9329 19.8078 12.0275 20.0256 12.0275C20.2433 12.0275 20.4502 11.9329 20.5927 11.7683L20.0256 11.2775ZM23.4462 7.3246L24.0134 7.81538C24.2572 7.53362 24.2572 7.11558 24.0134 6.83382L23.4462 7.3246ZM17.9731 1L18.5403 0.509223C18.3978 0.344598 18.1908 0.25 17.9731 0.25V1ZM7.02694 1V0.25C6.80923 0.25 6.60226 0.344598 6.4598 0.509223L7.02694 1ZM1.55383 7.3246L0.986702 6.83382C0.742877 7.11558 0.742877 7.53362 0.986702 7.81538L1.55383 7.3246ZM4.97452 11.2775L4.40739 11.7683C4.54985 11.9329 4.75682 12.0275 4.97452 12.0275C5.19223 12.0275 5.39919 11.9329 5.54165 11.7683L4.97452 11.2775ZM7.02694 8.90575H6.27694V15.2303H7.02694H7.77694V8.90575H7.02694ZM7.02694 15.2303V15.9803H17.9731V15.2303V14.4803H7.02694V15.2303ZM17.9731 15.2303H18.7231V8.90575H17.9731H17.2231V15.2303H17.9731ZM17.9731 8.90575L17.406 9.39653L19.4584 11.7683L20.0256 11.2775L20.5927 10.7867L18.5403 8.41497L17.9731 8.90575ZM20.0256 11.2775L20.5927 11.7683L24.0134 7.81538L23.4462 7.3246L22.8791 6.83382L19.4584 10.7867L20.0256 11.2775ZM23.4462 7.3246L24.0134 6.83382L18.5403 0.509223L17.9731 1L17.406 1.49078L22.8791 7.81538L23.4462 7.3246ZM17.9731 1V0.25H7.02694V1V1.75H17.9731V1ZM7.02694 1L6.4598 0.509223L0.986702 6.83382L1.55383 7.3246L2.12096 7.81538L7.59407 1.49078L7.02694 1ZM1.55383 7.3246L0.986702 7.81538L4.40739 11.7683L4.97452 11.2775L5.54165 10.7867L2.12096 6.83382L1.55383 7.3246ZM4.97452 11.2775L5.54165 11.7683L7.59407 9.39653L7.02694 8.90575L6.4598 8.41497L4.40739 10.7867L4.97452 11.2775Z'
-                    fill={teamInfo.uniformColors.primary}
-                  />
-                </svg>
-                <svg
-                  width='15'
-                  height='13'
-                  viewBox='0 0 15 13'
-                  fill='none'
+                  style={{
+                    fill: teamInfo.uniformColors.top,
+                  }}
+                />
+                <ShortsIcon
                   className={styles.shortsIcon}
+                  style={{
+                    fill: teamInfo.uniformColors.bottom,
+                  }}
+                />
+                <div
+                  className={styles.socksContainer}
+                  style={assignInlineVars({
+                    [styles.sockColorVar]: teamInfo.uniformColors.socks,
+                  })}
                 >
-                  <path
-                    d='M0.932617 11.5781L2.24616 1.72632H12.7545L14.0681 11.5781H8.15712L7.50034 7.47319L6.84357 11.5781H0.932617Z'
-                    stroke={teamInfo.uniformColors.secondary}
-                    strokeWidth='1.5'
-                    strokeLinejoin='round'
-                  />
-                </svg>
-                <div className={styles.socksContainer}>
-                  <div className={styles.sock}></div>
-                  <div className={styles.sock}></div>
+                  <div className={styles.sock} />
+                  <div className={styles.sock} />
                 </div>
               </div>
             </div>

--- a/src/routes/teams/$teamId/-components/TeamHeader.tsx
+++ b/src/routes/teams/$teamId/-components/TeamHeader.tsx
@@ -8,27 +8,41 @@ import {
 
 import * as styles from './TeamHeader.css';
 
-export const TeamHeader = () => {
+interface TeamInfo {
+  name: string;
+  description: string;
+  logoUrl: string;
+  leader: string;
+  foundedYear: number;
+  region: string;
+  memberCount: number;
+  uniformColors: {
+    primary: string;
+    secondary: string;
+  };
+}
+
+interface TeamHeaderProps {
+  teamInfo: TeamInfo;
+}
+
+export const TeamHeader = ({ teamInfo }: TeamHeaderProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.contentWrapper}>
-        {/* 팀 로고 및 정보 */}
         <div className={styles.teamInfoSection}>
           <div className={styles.logoContainer}>
             <img
-              src='/api/placeholder/66/78'
-              alt='FC Seoul Logo'
+              src={teamInfo.logoUrl}
+              alt={`${teamInfo.name} Logo`}
               className={styles.logoImage}
             />
           </div>
           <div className={styles.teamDetails}>
             <div className={styles.teamDetailsInner}>
               <div>
-                <h1 className={styles.teamName}>FC서울</h1>
-                <p className={styles.teamDescription}>
-                  서울의 자부심, FC 서울! 뜨거운 열정과 투지로 K리그를 이끄는
-                  명문 구단. 팬과 함께 성장하며 승리를 향해 나아갑니다.
-                </p>
+                <h1 className={styles.teamName}>{teamInfo.name}</h1>
+                <p className={styles.teamDescription}>{teamInfo.description}</p>
               </div>
               <div className={styles.editSection}>
                 <span className={styles.editText}>수정하기</span>
@@ -38,49 +52,38 @@ export const TeamHeader = () => {
           </div>
         </div>
 
-        {/* 팀 통계 */}
         <div className={styles.statsGrid}>
-          {/* 대표자 */}
           <div className={styles.statItem}>
             <div className={styles.statHeader}>
               <CrownIcon className={styles.statIcon} />
               <span className={styles.statLabel}>대표자</span>
             </div>
-            <span className={styles.statValue}>홍명보</span>
+            <span className={styles.statValue}>{teamInfo.leader}</span>
           </div>
-
-          {/* 창단연도 */}
           <div className={styles.statItem}>
             <div className={styles.statHeader}>
               <LoaderIcon className={styles.statIcon} />
               <span className={styles.statLabel}>창단연도</span>
             </div>
-            <span className={styles.statValue}>2025</span>
+            <span className={styles.statValue}>{teamInfo.foundedYear}</span>
           </div>
-
-          {/* 활동 지역 */}
           <div className={styles.statItem}>
             <div className={styles.statHeader}>
               <MapIcon className={styles.statIcon} />
               <span className={styles.statLabel}>활동 지역</span>
             </div>
-            <span className={styles.statValue}>서울 성동구</span>
+            <span className={styles.statValue}>{teamInfo.region}</span>
           </div>
-
-          {/* 활동 회원 수 */}
           <div className={styles.statItem}>
             <div className={styles.statHeader}>
               <UsersIcon className={styles.statIcon} />
               <span className={styles.statLabel}>활동 회원 수</span>
             </div>
-            <span className={styles.statValue}>43명</span>
+            <span className={styles.statValue}>{teamInfo.memberCount}명</span>
           </div>
-
-          {/* 유니폼 */}
           <div className={styles.uniformSection}>
             <span className={styles.uniformLabel}>유니폼</span>
             <div className={styles.uniformContainer}>
-              {/* 유니폼 아이콘 */}
               <div className={styles.uniformIcon}>
                 <svg
                   width='25'
@@ -91,10 +94,9 @@ export const TeamHeader = () => {
                 >
                   <path
                     d='M7.02694 8.90575H7.77694V6.89292L6.4598 8.41497L7.02694 8.90575ZM7.02694 15.2303H6.27694C6.27694 15.6446 6.61272 15.9803 7.02694 15.9803V15.2303ZM17.9731 15.2303V15.9803C18.3874 15.9803 18.7231 15.6446 18.7231 15.2303H17.9731ZM17.9731 8.90575L18.5403 8.41497L17.2231 6.89292V8.90575H17.9731ZM20.0256 11.2775L19.4584 11.7683C19.6009 11.9329 19.8078 12.0275 20.0256 12.0275C20.2433 12.0275 20.4502 11.9329 20.5927 11.7683L20.0256 11.2775ZM23.4462 7.3246L24.0134 7.81538C24.2572 7.53362 24.2572 7.11558 24.0134 6.83382L23.4462 7.3246ZM17.9731 1L18.5403 0.509223C18.3978 0.344598 18.1908 0.25 17.9731 0.25V1ZM7.02694 1V0.25C6.80923 0.25 6.60226 0.344598 6.4598 0.509223L7.02694 1ZM1.55383 7.3246L0.986702 6.83382C0.742877 7.11558 0.742877 7.53362 0.986702 7.81538L1.55383 7.3246ZM4.97452 11.2775L4.40739 11.7683C4.54985 11.9329 4.75682 12.0275 4.97452 12.0275C5.19223 12.0275 5.39919 11.9329 5.54165 11.7683L4.97452 11.2775ZM7.02694 8.90575H6.27694V15.2303H7.02694H7.77694V8.90575H7.02694ZM7.02694 15.2303V15.9803H17.9731V15.2303V14.4803H7.02694V15.2303ZM17.9731 15.2303H18.7231V8.90575H17.9731H17.2231V15.2303H17.9731ZM17.9731 8.90575L17.406 9.39653L19.4584 11.7683L20.0256 11.2775L20.5927 10.7867L18.5403 8.41497L17.9731 8.90575ZM20.0256 11.2775L20.5927 11.7683L24.0134 7.81538L23.4462 7.3246L22.8791 6.83382L19.4584 10.7867L20.0256 11.2775ZM23.4462 7.3246L24.0134 6.83382L18.5403 0.509223L17.9731 1L17.406 1.49078L22.8791 7.81538L23.4462 7.3246ZM17.9731 1V0.25H7.02694V1V1.75H17.9731V1ZM7.02694 1L6.4598 0.509223L0.986702 6.83382L1.55383 7.3246L2.12096 7.81538L7.59407 1.49078L7.02694 1ZM1.55383 7.3246L0.986702 7.81538L4.40739 11.7683L4.97452 11.2775L5.54165 10.7867L2.12096 6.83382L1.55383 7.3246ZM4.97452 11.2775L5.54165 11.7683L7.59407 9.39653L7.02694 8.90575L6.4598 8.41497L4.40739 10.7867L4.97452 11.2775Z'
-                    fill='#DBE4FF'
+                    fill={teamInfo.uniformColors.primary}
                   />
                 </svg>
-                {/* 바지 */}
                 <svg
                   width='15'
                   height='13'
@@ -104,12 +106,11 @@ export const TeamHeader = () => {
                 >
                   <path
                     d='M0.932617 11.5781L2.24616 1.72632H12.7545L14.0681 11.5781H8.15712L7.50034 7.47319L6.84357 11.5781H0.932617Z'
-                    stroke='#DBE4FF'
+                    stroke={teamInfo.uniformColors.secondary}
                     strokeWidth='1.5'
                     strokeLinejoin='round'
                   />
                 </svg>
-                {/* 양말 */}
                 <div className={styles.socksContainer}>
                   <div className={styles.sock}></div>
                   <div className={styles.sock}></div>

--- a/src/routes/teams/$teamId/-components/TeamHeader.tsx
+++ b/src/routes/teams/$teamId/-components/TeamHeader.tsx
@@ -1,0 +1,262 @@
+import * as styles from './TeamHeader.css';
+
+// 커스텀 아이콘 컴포넌트들
+const CrownIcon = ({ className }: { className?: string }) => (
+  <svg
+    width='28'
+    height='28'
+    viewBox='0 0 28 28'
+    fill='none'
+    className={className}
+  >
+    <path
+      d='M4.5 12.5L7 8.5L10.5 11L14 6L17.5 11L21 8.5L23.5 12.5L22 21H6L4.5 12.5Z'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <circle cx='14' cy='9' r='1.5' fill='currentColor' />
+    <circle cx='7' cy='8.5' r='1' fill='currentColor' />
+    <circle cx='21' cy='8.5' r='1' fill='currentColor' />
+  </svg>
+);
+
+const ClockIcon = ({ className }: { className?: string }) => (
+  <svg
+    width='28'
+    height='28'
+    viewBox='0 0 28 28'
+    fill='none'
+    className={className}
+  >
+    <circle
+      cx='14'
+      cy='14'
+      r='9'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <polyline
+      points='14,5 14,14 20,17'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+const MapIcon = ({ className }: { className?: string }) => (
+  <svg
+    width='28'
+    height='28'
+    viewBox='0 0 28 28'
+    fill='none'
+    className={className}
+  >
+    <polygon
+      points='3,6 9,4 21,8 21,18 15,20 3,16'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <line
+      x1='9'
+      y1='4'
+      x2='9'
+      y2='16'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <line
+      x1='15'
+      y1='8'
+      x2='15'
+      y2='20'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+const UsersIcon = ({ className }: { className?: string }) => (
+  <svg
+    width='28'
+    height='28'
+    viewBox='0 0 28 28'
+    fill='none'
+    className={className}
+  >
+    <path
+      d='M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <circle
+      cx='9'
+      cy='7'
+      r='4'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <path
+      d='M23 21v-2a4 4 0 0 0-3-3.87'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+    <path
+      d='M16 3.13a4 4 0 0 1 0 7.75'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+const ChevronRightIcon = ({ className }: { className?: string }) => (
+  <svg
+    width='24'
+    height='24'
+    viewBox='0 0 24 24'
+    fill='none'
+    className={className}
+  >
+    <path
+      d='M9 18L15 12L9 6'
+      stroke='currentColor'
+      strokeWidth='1.5'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
+  </svg>
+);
+
+export const TeamHeader = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.contentWrapper}>
+        {/* 팀 로고 및 정보 */}
+        <div className={styles.teamInfoSection}>
+          <div className={styles.logoContainer}>
+            <img
+              src='/api/placeholder/66/78'
+              alt='FC Seoul Logo'
+              className={styles.logoImage}
+            />
+          </div>
+          <div className={styles.teamDetails}>
+            <div className={styles.teamDetailsInner}>
+              <div>
+                <h1 className={styles.teamName}>FC서울</h1>
+                <p className={styles.teamDescription}>
+                  서울의 자부심, FC 서울! 뜨거운 열정과 투지로 K리그를 이끄는
+                  명문 구단. 팬과 함께 성장하며 승리를 향해 나아갑니다.
+                </p>
+              </div>
+              <div className={styles.editSection}>
+                <span className={styles.editText}>수정하기</span>
+                <ChevronRightIcon className={styles.chevronIcon} />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 팀 통계 */}
+        <div className={styles.statsGrid}>
+          {/* 대표자 */}
+          <div className={styles.statItem}>
+            <div className={styles.statHeader}>
+              <CrownIcon className={styles.statIcon} />
+              <span className={styles.statLabel}>대표자</span>
+            </div>
+            <span className={styles.statValue}>홍명보</span>
+          </div>
+
+          {/* 창단연도 */}
+          <div className={styles.statItem}>
+            <div className={styles.statHeader}>
+              <ClockIcon className={styles.statIcon} />
+              <span className={styles.statLabel}>창단연도</span>
+            </div>
+            <span className={styles.statValue}>2025</span>
+          </div>
+
+          {/* 활동 지역 */}
+          <div className={styles.statItem}>
+            <div className={styles.statHeader}>
+              <MapIcon className={styles.statIcon} />
+              <span className={styles.statLabel}>활동 지역</span>
+            </div>
+            <span className={styles.statValue}>서울 성동구</span>
+          </div>
+
+          {/* 활동 회원 수 */}
+          <div className={styles.statItem}>
+            <div className={styles.statHeader}>
+              <UsersIcon className={styles.statIcon} />
+              <span className={styles.statLabel}>활동 회원 수</span>
+            </div>
+            <span className={styles.statValue}>43명</span>
+          </div>
+
+          {/* 유니폼 */}
+          <div className={styles.uniformSection}>
+            <span className={styles.uniformLabel}>유니폼</span>
+            <div className={styles.uniformContainer}>
+              {/* 유니폼 아이콘 */}
+              <div className={styles.uniformIcon}>
+                <svg
+                  width='25'
+                  height='16'
+                  viewBox='0 0 25 16'
+                  fill='none'
+                  className={styles.jerseyIcon}
+                >
+                  <path
+                    d='M7.02694 8.90575H7.77694V6.89292L6.4598 8.41497L7.02694 8.90575ZM7.02694 15.2303H6.27694C6.27694 15.6446 6.61272 15.9803 7.02694 15.9803V15.2303ZM17.9731 15.2303V15.9803C18.3874 15.9803 18.7231 15.6446 18.7231 15.2303H17.9731ZM17.9731 8.90575L18.5403 8.41497L17.2231 6.89292V8.90575H17.9731ZM20.0256 11.2775L19.4584 11.7683C19.6009 11.9329 19.8078 12.0275 20.0256 12.0275C20.2433 12.0275 20.4502 11.9329 20.5927 11.7683L20.0256 11.2775ZM23.4462 7.3246L24.0134 7.81538C24.2572 7.53362 24.2572 7.11558 24.0134 6.83382L23.4462 7.3246ZM17.9731 1L18.5403 0.509223C18.3978 0.344598 18.1908 0.25 17.9731 0.25V1ZM7.02694 1V0.25C6.80923 0.25 6.60226 0.344598 6.4598 0.509223L7.02694 1ZM1.55383 7.3246L0.986702 6.83382C0.742877 7.11558 0.742877 7.53362 0.986702 7.81538L1.55383 7.3246ZM4.97452 11.2775L4.40739 11.7683C4.54985 11.9329 4.75682 12.0275 4.97452 12.0275C5.19223 12.0275 5.39919 11.9329 5.54165 11.7683L4.97452 11.2775ZM7.02694 8.90575H6.27694V15.2303H7.02694H7.77694V8.90575H7.02694ZM7.02694 15.2303V15.9803H17.9731V15.2303V14.4803H7.02694V15.2303ZM17.9731 15.2303H18.7231V8.90575H17.9731H17.2231V15.2303H17.9731ZM17.9731 8.90575L17.406 9.39653L19.4584 11.7683L20.0256 11.2775L20.5927 10.7867L18.5403 8.41497L17.9731 8.90575ZM20.0256 11.2775L20.5927 11.7683L24.0134 7.81538L23.4462 7.3246L22.8791 6.83382L19.4584 10.7867L20.0256 11.2775ZM23.4462 7.3246L24.0134 6.83382L18.5403 0.509223L17.9731 1L17.406 1.49078L22.8791 7.81538L23.4462 7.3246ZM17.9731 1V0.25H7.02694V1V1.75H17.9731V1ZM7.02694 1L6.4598 0.509223L0.986702 6.83382L1.55383 7.3246L2.12096 7.81538L7.59407 1.49078L7.02694 1ZM1.55383 7.3246L0.986702 7.81538L4.40739 11.7683L4.97452 11.2775L5.54165 10.7867L2.12096 6.83382L1.55383 7.3246ZM4.97452 11.2775L5.54165 11.7683L7.59407 9.39653L7.02694 8.90575L6.4598 8.41497L4.40739 10.7867L4.97452 11.2775Z'
+                    fill='#DBE4FF'
+                  />
+                </svg>
+                {/* 바지 */}
+                <svg
+                  width='15'
+                  height='13'
+                  viewBox='0 0 15 13'
+                  fill='none'
+                  className={styles.shortsIcon}
+                >
+                  <path
+                    d='M0.932617 11.5781L2.24616 1.72632H12.7545L14.0681 11.5781H8.15712L7.50034 7.47319L6.84357 11.5781H0.932617Z'
+                    stroke='#DBE4FF'
+                    strokeWidth='1.5'
+                    strokeLinejoin='round'
+                  />
+                </svg>
+                {/* 양말 */}
+                <div className={styles.socksContainer}>
+                  <div className={styles.sock}></div>
+                  <div className={styles.sock}></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/routes/teams/$teamId/-components/TeamHeader.tsx
+++ b/src/routes/teams/$teamId/-components/TeamHeader.tsx
@@ -10,23 +10,9 @@ import {
   UsersIcon,
 } from '@/assets/icons';
 import DefaultTeamLogo from '@/assets/images/teams/default-team-logo.svg?react';
+import type { TeamInfo } from '@/routes/teams/$teamId/-temp-server-types';
 
 import * as styles from './TeamHeader.css';
-
-interface TeamInfo {
-  name: string;
-  description: string;
-  logoUrl: string | null;
-  leader: string;
-  foundedYear: number;
-  region: string;
-  memberCount: number;
-  uniformColors: {
-    top: string;
-    bottom: string;
-    socks: string;
-  };
-}
 
 interface TeamHeaderProps {
   teamInfo: TeamInfo;

--- a/src/routes/teams/$teamId/-components/TeamHeader.tsx
+++ b/src/routes/teams/$teamId/-components/TeamHeader.tsx
@@ -1,150 +1,12 @@
+import {
+  ArrowRightIcon,
+  CrownIcon,
+  LoaderIcon,
+  MapIcon,
+  UsersIcon,
+} from '@/assets/icons';
+
 import * as styles from './TeamHeader.css';
-
-// 커스텀 아이콘 컴포넌트들
-const CrownIcon = ({ className }: { className?: string }) => (
-  <svg
-    width='28'
-    height='28'
-    viewBox='0 0 28 28'
-    fill='none'
-    className={className}
-  >
-    <path
-      d='M4.5 12.5L7 8.5L10.5 11L14 6L17.5 11L21 8.5L23.5 12.5L22 21H6L4.5 12.5Z'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <circle cx='14' cy='9' r='1.5' fill='currentColor' />
-    <circle cx='7' cy='8.5' r='1' fill='currentColor' />
-    <circle cx='21' cy='8.5' r='1' fill='currentColor' />
-  </svg>
-);
-
-const ClockIcon = ({ className }: { className?: string }) => (
-  <svg
-    width='28'
-    height='28'
-    viewBox='0 0 28 28'
-    fill='none'
-    className={className}
-  >
-    <circle
-      cx='14'
-      cy='14'
-      r='9'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <polyline
-      points='14,5 14,14 20,17'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
-
-const MapIcon = ({ className }: { className?: string }) => (
-  <svg
-    width='28'
-    height='28'
-    viewBox='0 0 28 28'
-    fill='none'
-    className={className}
-  >
-    <polygon
-      points='3,6 9,4 21,8 21,18 15,20 3,16'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <line
-      x1='9'
-      y1='4'
-      x2='9'
-      y2='16'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <line
-      x1='15'
-      y1='8'
-      x2='15'
-      y2='20'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
-
-const UsersIcon = ({ className }: { className?: string }) => (
-  <svg
-    width='28'
-    height='28'
-    viewBox='0 0 28 28'
-    fill='none'
-    className={className}
-  >
-    <path
-      d='M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <circle
-      cx='9'
-      cy='7'
-      r='4'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <path
-      d='M23 21v-2a4 4 0 0 0-3-3.87'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-    <path
-      d='M16 3.13a4 4 0 0 1 0 7.75'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
-
-const ChevronRightIcon = ({ className }: { className?: string }) => (
-  <svg
-    width='24'
-    height='24'
-    viewBox='0 0 24 24'
-    fill='none'
-    className={className}
-  >
-    <path
-      d='M9 18L15 12L9 6'
-      stroke='currentColor'
-      strokeWidth='1.5'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    />
-  </svg>
-);
 
 export const TeamHeader = () => {
   return (
@@ -170,7 +32,7 @@ export const TeamHeader = () => {
               </div>
               <div className={styles.editSection}>
                 <span className={styles.editText}>수정하기</span>
-                <ChevronRightIcon className={styles.chevronIcon} />
+                <ArrowRightIcon className={styles.chevronIcon} />
               </div>
             </div>
           </div>
@@ -190,7 +52,7 @@ export const TeamHeader = () => {
           {/* 창단연도 */}
           <div className={styles.statItem}>
             <div className={styles.statHeader}>
-              <ClockIcon className={styles.statIcon} />
+              <LoaderIcon className={styles.statIcon} />
               <span className={styles.statLabel}>창단연도</span>
             </div>
             <span className={styles.statValue}>2025</span>

--- a/src/routes/teams/$teamId/-components/TeamHeader.tsx
+++ b/src/routes/teams/$teamId/-components/TeamHeader.tsx
@@ -1,7 +1,7 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 import {
-  ArrowRightIcon,
+  ChevronRightIcon,
   CrownIcon,
   JerseyIcon,
   LoaderIcon,
@@ -57,7 +57,7 @@ export const TeamHeader = ({ teamInfo }: TeamHeaderProps) => {
               </div>
               <div className={styles.editSection}>
                 <span className={styles.editText}>수정하기</span>
-                <ArrowRightIcon className={styles.chevronIcon} />
+                <ChevronRightIcon className={styles.chevronIcon} />
               </div>
             </div>
           </div>

--- a/src/routes/teams/$teamId/-components/index.ts
+++ b/src/routes/teams/$teamId/-components/index.ts
@@ -1,0 +1,4 @@
+export * from './TeamHeader';
+export * from './RecentRecords';
+export * from './ScheduleCalendar';
+export * from './NoticeBoard';

--- a/src/routes/teams/$teamId/-mock-data.ts
+++ b/src/routes/teams/$teamId/-mock-data.ts
@@ -1,0 +1,164 @@
+import { ApiResponse, TeamResponse } from '@/apis/models';
+
+import type {
+  CalendarDay,
+  MatchResult,
+  Notice,
+  TeamInfo,
+} from './-temp-server-types';
+
+export function createTeamAndMatch(teamResponse: ApiResponse<TeamResponse>) {
+  const teamInfo: TeamInfo = {
+    name: teamResponse.data.name,
+    description: `${teamResponse.data.name}의 팀 소개입니다.`,
+    logoUrl: teamResponse.data.teamImg,
+    leader: '팀 리더',
+    foundedYear: 2025,
+    region: '지역 정보',
+    memberCount: 43,
+    uniformColors: {
+      top: teamResponse.data.teamColor,
+      bottom: teamResponse.data.bottomColor,
+      socks: teamResponse.data.stockingColor,
+    },
+  };
+
+  const matchResults: MatchResult[] = [
+    {
+      date: '2025-04-23',
+      duration: '96"',
+      homeTeam: {
+        name: teamResponse.data.name,
+        logo: null,
+        score: 1,
+        uniformColor: {
+          top: teamResponse.data.teamColor,
+          bottom: teamResponse.data.bottomColor,
+          socks: teamResponse.data.stockingColor,
+        },
+      },
+      awayTeam: {
+        name: 'FC 수원',
+        logo: null,
+        score: 2,
+        uniformColor: {
+          top: '#2196F3',
+          bottom: teamResponse.data.bottomColor,
+          socks: teamResponse.data.stockingColor,
+        },
+      },
+    },
+    {
+      date: '2025-04-01',
+      duration: '90"',
+      homeTeam: {
+        name: teamResponse.data.name,
+        logo: null,
+        score: 1,
+        uniformColor: {
+          top: teamResponse.data.teamColor,
+          bottom: teamResponse.data.bottomColor,
+          socks: teamResponse.data.stockingColor,
+        },
+      },
+      awayTeam: {
+        name: 'FC 전남',
+        logo: null,
+        score: 1,
+        uniformColor: {
+          top: '#8BC34A',
+          bottom: teamResponse.data.bottomColor,
+          socks: teamResponse.data.stockingColor,
+        },
+      },
+    },
+    {
+      date: '2025-03-21',
+      duration: '94"',
+      homeTeam: {
+        name: teamResponse.data.name,
+        logo: null,
+        score: 3,
+        uniformColor: {
+          top: teamResponse.data.teamColor,
+          bottom: teamResponse.data.bottomColor,
+          socks: teamResponse.data.stockingColor,
+        },
+      },
+      awayTeam: {
+        name: 'FC 안양',
+        logo: null,
+        score: 0,
+        uniformColor: {
+          top: '#3F51B5',
+          bottom: teamResponse.data.bottomColor,
+          socks: teamResponse.data.stockingColor,
+        },
+      },
+    },
+  ];
+
+  return { teamInfo, matchResults };
+}
+
+export const notices: Notice[] = [
+  {
+    title: '신입 선수 모집 안내 (2025년 봄 시즌)',
+    author: '홍명보',
+    date: '2025-04-12',
+  },
+  {
+    title: '주말 정기 연습 일정 변경 안내 – 장소 및 시간을 꼭 확인해주세요!',
+    author: '홍명보',
+    date: '2025-03-27',
+  },
+  {
+    title: '우리 동네 대표로 출전! 지역 친선 경기 참가자 모집합니다',
+    author: '홍명보',
+    date: '2025-03-24',
+  },
+];
+
+export const calendarDays: CalendarDay[] = [
+  // 이전 달 날짜들 (3월 29-31일)
+  { day: 29, isCurrentMonth: false },
+  { day: 30, isCurrentMonth: false },
+  { day: 31, isCurrentMonth: false },
+  // 현재 달 날짜들 (4월)
+  { day: 1, isCurrentMonth: true },
+  { day: 2, isCurrentMonth: true },
+  { day: 3, isCurrentMonth: true },
+  { day: 4, isCurrentMonth: true, hasEvent: true },
+  { day: 5, isCurrentMonth: true },
+  { day: 6, isCurrentMonth: true },
+  { day: 7, isCurrentMonth: true },
+  { day: 8, isCurrentMonth: true },
+  { day: 9, isCurrentMonth: true },
+  { day: 10, isCurrentMonth: true },
+  { day: 11, isCurrentMonth: true },
+  { day: 12, isCurrentMonth: true },
+  { day: 13, isCurrentMonth: true, hasEvent: true },
+  { day: 14, isCurrentMonth: true },
+  { day: 15, isCurrentMonth: true },
+  { day: 16, isCurrentMonth: true },
+  { day: 17, isCurrentMonth: true, isSelected: true, hasEvent: true },
+  { day: 18, isCurrentMonth: true },
+  { day: 19, isCurrentMonth: true },
+  { day: 20, isCurrentMonth: true, hasEvent: true },
+  { day: 21, isCurrentMonth: true },
+  { day: 22, isCurrentMonth: true, hasEvent: true },
+  { day: 23, isCurrentMonth: true },
+  { day: 24, isCurrentMonth: true },
+  { day: 25, isCurrentMonth: true },
+  { day: 26, isCurrentMonth: true },
+  { day: 27, isCurrentMonth: true },
+  { day: 28, isCurrentMonth: true },
+  { day: 29, isCurrentMonth: true },
+  { day: 30, isCurrentMonth: true },
+  // 다음 달 날짜들 (5월 1-3일)
+  { day: 1, isCurrentMonth: false },
+  { day: 2, isCurrentMonth: false },
+  { day: 3, isCurrentMonth: false },
+];
+
+export const currentMonth = '2025-04';

--- a/src/routes/teams/$teamId/-route.css.ts
+++ b/src/routes/teams/$teamId/-route.css.ts
@@ -1,63 +1,53 @@
+import { commonPageRoot } from '@/styles/page.css';
 import { lightThemeVars } from '@/styles/theme.css';
 
 import { style } from '@vanilla-extract/css';
 
-export const pageContainer = style({
-  backgroundColor: '#F9FAFB',
-  minHeight: '100vh',
-});
-
-export const outerContainer = style({
-  margin: '0 auto',
-  padding: '52px 52px 90px',
-  maxWidth: 1440,
-});
+export const rootContainer = style([
+  commonPageRoot,
+  {
+    backgroundColor: lightThemeVars.color.white.background,
+    paddingTop: 60,
+    paddingBottom: 60,
+  },
+]);
 
 export const mainCard = style({
-  margin: '0 auto',
   borderRadius: 8,
   boxShadow: '4px 4px 8px 0px rgba(0,0,0,0.05)',
   backgroundColor: lightThemeVars.color.white.main,
-  width: '100%',
-  maxWidth: 1336,
+  width: 1336,
 });
 
-export const contentContainer = style({
-  padding: '24px 40px',
+export const bodyContainer = style({
+  display: 'flex',
+  gap: 11,
+  padding: '19px 40px',
 });
 
-export const topSection = style({
-  position: 'relative',
+export const leftContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 20,
 });
 
-export const grid = style({
-  display: 'grid',
-  gridTemplateColumns: '776px 1fr',
-  gap: 0,
-});
-
-export const recordsSection = style({
-  paddingRight: 40,
-});
-
-export const verticalDivider = style({
-  position: 'absolute',
-  top: 24,
-  left: 807,
-  display: 'block',
-  backgroundColor: lightThemeVars.color.primary[100],
-  width: 1,
-  height: 444,
-});
-
-export const scheduleSection = style({
-  marginTop: 0,
-  paddingLeft: 40,
+export const rightContainer = style({
+  paddingLeft: 31,
 });
 
 export const horizontalDivider = style({
-  margin: '24px 0',
+  marginLeft: 20,
   backgroundColor: lightThemeVars.color.primary[100],
-  width: '100%',
+  width: 787,
   height: 1,
+});
+
+export const verticalDivider = style({
+  display: 'block',
+  flexShrink: 0,
+  marginTop: 25,
+  marginLeft: -11,
+  backgroundColor: lightThemeVars.color.primary[100],
+  width: 1,
+  height: 444,
 });

--- a/src/routes/teams/$teamId/-route.css.ts
+++ b/src/routes/teams/$teamId/-route.css.ts
@@ -1,0 +1,63 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const pageContainer = style({
+  backgroundColor: '#F9FAFB',
+  minHeight: '100vh',
+});
+
+export const outerContainer = style({
+  margin: '0 auto',
+  padding: '52px 52px 90px',
+  maxWidth: 1440,
+});
+
+export const mainCard = style({
+  margin: '0 auto',
+  borderRadius: 8,
+  boxShadow: '4px 4px 8px 0px rgba(0,0,0,0.05)',
+  backgroundColor: lightThemeVars.color.white.main,
+  width: '100%',
+  maxWidth: 1336,
+});
+
+export const contentContainer = style({
+  padding: '24px 40px',
+});
+
+export const topSection = style({
+  position: 'relative',
+});
+
+export const grid = style({
+  display: 'grid',
+  gridTemplateColumns: '776px 1fr',
+  gap: 0,
+});
+
+export const recordsSection = style({
+  paddingRight: 40,
+});
+
+export const verticalDivider = style({
+  position: 'absolute',
+  top: 24,
+  left: 807,
+  display: 'block',
+  backgroundColor: lightThemeVars.color.primary[100],
+  width: 1,
+  height: 444,
+});
+
+export const scheduleSection = style({
+  marginTop: 0,
+  paddingLeft: 40,
+});
+
+export const horizontalDivider = style({
+  margin: '24px 0',
+  backgroundColor: lightThemeVars.color.primary[100],
+  width: '100%',
+  height: 1,
+});

--- a/src/routes/teams/$teamId/-temp-server-types.ts
+++ b/src/routes/teams/$teamId/-temp-server-types.ts
@@ -1,0 +1,52 @@
+export interface TeamInfo {
+  name: string;
+  description: string;
+  logoUrl: string | null;
+  leader: string;
+  foundedYear: number;
+  region: string;
+  memberCount: number;
+  uniformColors: {
+    top: string;
+    bottom: string;
+    socks: string;
+  };
+}
+
+export interface MatchResult {
+  date: string;
+  duration: string;
+  homeTeam: {
+    name: string;
+    logo: string | null;
+    score: number;
+    uniformColor: {
+      top: string;
+      bottom: string;
+      socks: string;
+    };
+  };
+  awayTeam: {
+    name: string;
+    logo: string | null;
+    score: number;
+    uniformColor: {
+      top: string;
+      bottom: string;
+      socks: string;
+    };
+  };
+}
+
+export interface Notice {
+  title: string;
+  author: string;
+  date: string;
+}
+
+export interface CalendarDay {
+  day: number;
+  isCurrentMonth: boolean;
+  isSelected?: boolean;
+  hasEvent?: boolean;
+}

--- a/src/routes/teams/$teamId/route.tsx
+++ b/src/routes/teams/$teamId/route.tsx
@@ -11,7 +11,14 @@ import {
   ScheduleCalendar,
   TeamHeader,
 } from './-components';
+import {
+  calendarDays,
+  createTeamAndMatch,
+  currentMonth,
+  notices,
+} from './-mock-data';
 import * as styles from './-route.css';
+import type { MatchResult, TeamInfo } from './-temp-server-types';
 
 export const Route = createFileRoute('/teams/$teamId')({
   component: TeamDetailPage,
@@ -22,49 +29,6 @@ export const Route = createFileRoute('/teams/$teamId')({
   },
 });
 
-interface TeamInfo {
-  name: string;
-  description: string;
-  logoUrl: string | null;
-  leader: string;
-  foundedYear: number;
-  region: string;
-  memberCount: number;
-  uniformColors: {
-    top: string;
-    bottom: string;
-    socks: string;
-  };
-}
-
-interface MatchResult {
-  date: string;
-  duration: string;
-  homeTeam: {
-    name: string;
-    logo: string;
-    score: number;
-  };
-  awayTeam: {
-    name: string;
-    logo: string;
-    score: number;
-  };
-}
-
-interface Notice {
-  title: string;
-  author: string;
-  date: string;
-}
-
-interface CalendarDay {
-  day: number;
-  isCurrentMonth: boolean;
-  isSelected?: boolean;
-  hasEvent?: boolean;
-}
-
 function TeamDetailPage() {
   const { teamId } = Route.useParams();
   usePageTitle('팀 프로필');
@@ -73,127 +37,11 @@ function TeamDetailPage() {
     teamQuery.byId(Number(teamId)),
   );
 
-  const teamInfo: TeamInfo = {
-    name: teamResponse.data.name,
-    description: `${teamResponse.data.name}의 팀 소개입니다.`,
-    logoUrl: teamResponse.data.teamImg,
-    leader: '팀 리더',
-    foundedYear: 2025,
-    region: '지역 정보',
-    memberCount: 43,
-    uniformColors: {
-      top: teamResponse.data.teamColor,
-      bottom: teamResponse.data.bottomColor,
-      socks: teamResponse.data.stockingColor,
-    },
-  };
-
-  const matchResults: MatchResult[] = [
-    {
-      date: '2025-04-23',
-      duration: '96"',
-      homeTeam: {
-        name: 'FC 서울',
-        logo: '/api/placeholder/44/44',
-        score: 1,
-      },
-      awayTeam: {
-        name: 'FC 수원',
-        logo: '/api/placeholder/44/44',
-        score: 2,
-      },
-    },
-    {
-      date: '2025-04-01',
-      duration: '90"',
-      homeTeam: {
-        name: 'FC 서울',
-        logo: '/api/placeholder/44/44',
-        score: 1,
-      },
-      awayTeam: {
-        name: 'FC 수원',
-        logo: '/api/placeholder/44/44',
-        score: 1,
-      },
-    },
-    {
-      date: '2025-03-21',
-      duration: '94"',
-      homeTeam: {
-        name: 'FC 서울',
-        logo: '/api/placeholder/44/44',
-        score: 3,
-      },
-      awayTeam: {
-        name: 'FC 수원',
-        logo: '/api/placeholder/44/44',
-        score: 0,
-      },
-    },
-  ];
-
-  const notices: Notice[] = [
-    {
-      title: '신입 선수 모집 안내 (2025년 봄 시즌)',
-      author: '홍명보',
-      date: '2025-04-12',
-    },
-    {
-      title: '주말 정기 연습 일정 변경 안내 – 장소 및 시간을 꼭 확인해주세요!',
-      author: '홍명보',
-      date: '2025-03-27',
-    },
-    {
-      title: '우리 동네 대표로 출전! 지역 친선 경기 참가자 모집합니다',
-      author: '홍명보',
-      date: '2025-03-24',
-    },
-  ];
-
-  const calendarDays: CalendarDay[] = [
-    // 이전 달 날짜들 (3월 29-31일)
-    { day: 29, isCurrentMonth: false },
-    { day: 30, isCurrentMonth: false },
-    { day: 31, isCurrentMonth: false },
-    // 현재 달 날짜들 (4월)
-    { day: 1, isCurrentMonth: true },
-    { day: 2, isCurrentMonth: true },
-    { day: 3, isCurrentMonth: true },
-    { day: 4, isCurrentMonth: true, hasEvent: true },
-    { day: 5, isCurrentMonth: true },
-    { day: 6, isCurrentMonth: true },
-    { day: 7, isCurrentMonth: true },
-    { day: 8, isCurrentMonth: true },
-    { day: 9, isCurrentMonth: true },
-    { day: 10, isCurrentMonth: true },
-    { day: 11, isCurrentMonth: true },
-    { day: 12, isCurrentMonth: true },
-    { day: 13, isCurrentMonth: true, hasEvent: true },
-    { day: 14, isCurrentMonth: true },
-    { day: 15, isCurrentMonth: true },
-    { day: 16, isCurrentMonth: true },
-    { day: 17, isCurrentMonth: true, isSelected: true, hasEvent: true },
-    { day: 18, isCurrentMonth: true },
-    { day: 19, isCurrentMonth: true },
-    { day: 20, isCurrentMonth: true, hasEvent: true },
-    { day: 21, isCurrentMonth: true },
-    { day: 22, isCurrentMonth: true, hasEvent: true },
-    { day: 23, isCurrentMonth: true },
-    { day: 24, isCurrentMonth: true },
-    { day: 25, isCurrentMonth: true },
-    { day: 26, isCurrentMonth: true },
-    { day: 27, isCurrentMonth: true },
-    { day: 28, isCurrentMonth: true },
-    { day: 29, isCurrentMonth: true },
-    { day: 30, isCurrentMonth: true },
-    // 다음 달 날짜들 (5월 1-3일)
-    { day: 1, isCurrentMonth: false },
-    { day: 2, isCurrentMonth: false },
-    { day: 3, isCurrentMonth: false },
-  ];
-
-  const currentMonth = '2025-04';
+  const {
+    teamInfo,
+    matchResults,
+  }: { teamInfo: TeamInfo; matchResults: MatchResult[] } =
+    createTeamAndMatch(teamResponse);
 
   return (
     <div className={styles.rootContainer}>

--- a/src/routes/teams/$teamId/route.tsx
+++ b/src/routes/teams/$teamId/route.tsx
@@ -1,0 +1,44 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { usePageTitle } from '@/hooks';
+
+import {
+  NoticeBoard,
+  RecentRecords,
+  ScheduleCalendar,
+  TeamHeader,
+} from './-components';
+import * as styles from './-route.css';
+
+export const Route = createFileRoute('/teams/$teamId')({
+  component: TeamDetailPage,
+});
+
+function TeamDetailPage() {
+  usePageTitle('팀 프로필');
+
+  return (
+    <div className={styles.pageContainer}>
+      <div className={styles.outerContainer}>
+        <div className={styles.mainCard}>
+          <TeamHeader />
+          <div className={styles.contentContainer}>
+            <div className={styles.topSection}>
+              <div className={styles.grid}>
+                <div className={styles.recordsSection}>
+                  <RecentRecords />
+                </div>
+                <div className={styles.verticalDivider}></div>
+                <div className={styles.scheduleSection}>
+                  <ScheduleCalendar />
+                </div>
+              </div>
+            </div>
+            <div className={styles.horizontalDivider}></div>
+            <NoticeBoard />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/teams/$teamId/route.tsx
+++ b/src/routes/teams/$teamId/route.tsx
@@ -14,28 +14,200 @@ export const Route = createFileRoute('/teams/$teamId')({
   component: TeamDetailPage,
 });
 
+// 구단 정보 타입
+interface TeamInfo {
+  name: string;
+  description: string;
+  logoUrl: string;
+  leader: string;
+  foundedYear: number;
+  region: string;
+  memberCount: number;
+  uniformColors: {
+    primary: string;
+    secondary: string;
+  };
+}
+
+// 경기 기록 타입
+interface MatchResult {
+  date: string;
+  duration: string;
+  homeTeam: {
+    name: string;
+    logo: string;
+    score: number;
+  };
+  awayTeam: {
+    name: string;
+    logo: string;
+    score: number;
+  };
+}
+
+// 공지사항 타입
+interface Notice {
+  title: string;
+  author: string;
+  date: string;
+}
+
+// 캘린더 일정 타입
+interface CalendarDay {
+  day: number;
+  isCurrentMonth: boolean;
+  isSelected?: boolean;
+  hasEvent?: boolean;
+}
+
 function TeamDetailPage() {
   usePageTitle('팀 프로필');
+
+  // 임시 데이터 - 실제로는 API나 상태 관리에서 가져올 데이터
+  const teamInfo: TeamInfo = {
+    name: 'FC서울',
+    description:
+      '서울의 자부심, FC 서울! 뜨거운 열정과 투지로 K리그를 이끄는 명문 구단. 팬과 함께 성장하며 승리를 향해 나아갑니다.',
+    logoUrl: '/api/placeholder/66/78',
+    leader: '홍명보',
+    foundedYear: 2025,
+    region: '서울 성동구',
+    memberCount: 43,
+    uniformColors: {
+      primary: '#DBE4FF',
+      secondary: '#DBE4FF',
+    },
+  };
+
+  const matchResults: MatchResult[] = [
+    {
+      date: '2025-04-23',
+      duration: '96"',
+      homeTeam: {
+        name: 'FC 서울',
+        logo: '/api/placeholder/44/44',
+        score: 1,
+      },
+      awayTeam: {
+        name: 'FC 수원',
+        logo: '/api/placeholder/44/44',
+        score: 2,
+      },
+    },
+    {
+      date: '2025-04-01',
+      duration: '90"',
+      homeTeam: {
+        name: 'FC 서울',
+        logo: '/api/placeholder/44/44',
+        score: 1,
+      },
+      awayTeam: {
+        name: 'FC 수원',
+        logo: '/api/placeholder/44/44',
+        score: 1,
+      },
+    },
+    {
+      date: '2025-03-21',
+      duration: '94"',
+      homeTeam: {
+        name: 'FC 서울',
+        logo: '/api/placeholder/44/44',
+        score: 3,
+      },
+      awayTeam: {
+        name: 'FC 수원',
+        logo: '/api/placeholder/44/44',
+        score: 0,
+      },
+    },
+  ];
+
+  const notices: Notice[] = [
+    {
+      title: '신입 선수 모집 안내 (2025년 봄 시즌)',
+      author: '홍명보',
+      date: '2025-04-12',
+    },
+    {
+      title: '주말 정기 연습 일정 변경 안내 – 장소 및 시간을 꼭 확인해주세요!',
+      author: '홍명보',
+      date: '2025-03-27',
+    },
+    {
+      title: '우리 동네 대표로 출전! 지역 친선 경기 참가자 모집합니다',
+      author: '홍명보',
+      date: '2025-03-24',
+    },
+  ];
+
+  const calendarDays: CalendarDay[] = [
+    // 이전 달 날짜들 (3월 29-31일)
+    { day: 29, isCurrentMonth: false },
+    { day: 30, isCurrentMonth: false },
+    { day: 31, isCurrentMonth: false },
+    // 현재 달 날짜들 (4월)
+    { day: 1, isCurrentMonth: true },
+    { day: 2, isCurrentMonth: true },
+    { day: 3, isCurrentMonth: true },
+    { day: 4, isCurrentMonth: true, hasEvent: true },
+    { day: 5, isCurrentMonth: true },
+    { day: 6, isCurrentMonth: true },
+    { day: 7, isCurrentMonth: true },
+    { day: 8, isCurrentMonth: true },
+    { day: 9, isCurrentMonth: true },
+    { day: 10, isCurrentMonth: true },
+    { day: 11, isCurrentMonth: true },
+    { day: 12, isCurrentMonth: true },
+    { day: 13, isCurrentMonth: true, hasEvent: true },
+    { day: 14, isCurrentMonth: true },
+    { day: 15, isCurrentMonth: true },
+    { day: 16, isCurrentMonth: true },
+    { day: 17, isCurrentMonth: true, isSelected: true, hasEvent: true },
+    { day: 18, isCurrentMonth: true },
+    { day: 19, isCurrentMonth: true },
+    { day: 20, isCurrentMonth: true, hasEvent: true },
+    { day: 21, isCurrentMonth: true },
+    { day: 22, isCurrentMonth: true, hasEvent: true },
+    { day: 23, isCurrentMonth: true },
+    { day: 24, isCurrentMonth: true },
+    { day: 25, isCurrentMonth: true },
+    { day: 26, isCurrentMonth: true },
+    { day: 27, isCurrentMonth: true },
+    { day: 28, isCurrentMonth: true },
+    { day: 29, isCurrentMonth: true },
+    { day: 30, isCurrentMonth: true },
+    // 다음 달 날짜들 (5월 1-3일)
+    { day: 1, isCurrentMonth: false },
+    { day: 2, isCurrentMonth: false },
+    { day: 3, isCurrentMonth: false },
+  ];
+
+  const currentMonth = '2025-04';
 
   return (
     <div className={styles.pageContainer}>
       <div className={styles.outerContainer}>
         <div className={styles.mainCard}>
-          <TeamHeader />
+          <TeamHeader teamInfo={teamInfo} />
           <div className={styles.contentContainer}>
             <div className={styles.topSection}>
               <div className={styles.grid}>
                 <div className={styles.recordsSection}>
-                  <RecentRecords />
+                  <RecentRecords matchResults={matchResults} />
                 </div>
                 <div className={styles.verticalDivider}></div>
                 <div className={styles.scheduleSection}>
-                  <ScheduleCalendar />
+                  <ScheduleCalendar
+                    currentMonth={currentMonth}
+                    calendarDays={calendarDays}
+                  />
                 </div>
               </div>
             </div>
             <div className={styles.horizontalDivider}></div>
-            <NoticeBoard />
+            <NoticeBoard notices={notices} />
           </div>
         </div>
       </div>

--- a/src/routes/teams/$teamId/route.tsx
+++ b/src/routes/teams/$teamId/route.tsx
@@ -196,27 +196,21 @@ function TeamDetailPage() {
   const currentMonth = '2025-04';
 
   return (
-    <div className={styles.pageContainer}>
-      <div className={styles.outerContainer}>
-        <div className={styles.mainCard}>
-          <TeamHeader teamInfo={teamInfo} />
-          <div className={styles.contentContainer}>
-            <div className={styles.topSection}>
-              <div className={styles.grid}>
-                <div className={styles.recordsSection}>
-                  <RecentRecords matchResults={matchResults} />
-                </div>
-                <div className={styles.verticalDivider}></div>
-                <div className={styles.scheduleSection}>
-                  <ScheduleCalendar
-                    currentMonth={currentMonth}
-                    calendarDays={calendarDays}
-                  />
-                </div>
-              </div>
-            </div>
+    <div className={styles.rootContainer}>
+      <div className={styles.mainCard}>
+        <TeamHeader teamInfo={teamInfo} />
+        <div className={styles.bodyContainer}>
+          <div className={styles.leftContainer}>
+            <RecentRecords matchResults={matchResults} />
             <div className={styles.horizontalDivider}></div>
             <NoticeBoard notices={notices} />
+          </div>
+          <div className={styles.verticalDivider}></div>
+          <div className={styles.rightContainer}>
+            <ScheduleCalendar
+              currentMonth={currentMonth}
+              calendarDays={calendarDays}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-355](https://match-day.atlassian.net/browse/MAT-355) 팀 요약 영역 퍼블리싱
- [Jira Ticket: MAT-356](https://match-day.atlassian.net/browse/MAT-356) 팀 최근 기록 영역 퍼블리싱
- [Jira Ticket: MAT-357](https://match-day.atlassian.net/browse/MAT-357) 팀 공지사항 리스트 퍼블리싱
- [Jira Ticket: MAT-358](https://match-day.atlassian.net/browse/MAT-358) 팀 일정 캘린더 퍼블리싱

## Changes

- [x] 아이콘 8종 추가 (ChevronLeftIcon, ChevronRightIcon, CrownIcon, LoaderIcon, MapIcon, UsersIcon, JerseyIcon, ShortsIcon)
- [x] 현재 수준의 팀 조회 API 연동
- [x] 임시 목 데이터 추가 (서버 API 스펙x)

### Screenshots

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/03567773-73c3-4c29-8847-08566205cd02" />


## Todo

- [ ] 동작 구현하면서 인터렉션에 부적절한 부분은 수정 예정
- [ ] 사이드바 토글 버튼이 사라졌는데 복구 예정