### PR TITLE
feat: MAT-365 팀 일정 페이지 퍼블리싱

### DIFF
--- a/.cursor/rules/coding-standards.mdc
+++ b/.cursor/rules/coding-standards.mdc
@@ -22,9 +22,12 @@ alwaysApply: true
 - 개별적인 padding 값을 줘야 하는 경우 shorthand를 사용한다.
 - Figma 기반으로 화면을 생성할 때 Layer를 그대로 옮기기보다 최소 마크업/스타일로 작성한다. 즉, 부득이한 경우가 아니라면 자식이 하나만 있는 element를 중첩하지 않는다.
 - 아직 baseline으로 지원되지 않는 스타일은 지양한다 (fit-content, max-content 등)
-- alignItems: stretch 와 같은 CSS 기본값은 명시적으로 사용하지 않는다.
 - CSS 작성 시에는 shorthand를 선호하며, Vanilla Extract에서 숫자로 표현할 수 있는 값은 숫자로 표현한다. (e.g. "padding: 40px 40px" -> "padding: 40")
-- alignSelf: stretch 옵션은 최소한으로 사용한다.
+- `justifyContent: flex-start`, `alignItems: stretch`, `alignSelf: stretch`와 같은 기본 옵션은 사용하지 않는다.
+- 해당 프로젝트는 PC 해상도만 지원하므로 불필요한 태블릿/모바일 해상도 화면을 위한 반응형 스타일을 작성하지 않는다.
+
+## Storybook 컨벤션
+- 중복되지 않는 Mock Data는 파일 상단에 정의하지 않고, 각 Story의 parameters에서 인라인으로 정의하고 넘긴다.
 
 ## 네이밍 컨벤션
 - 컴포넌트명: PascalCase (예: `TeamCreatePage`)
@@ -35,6 +38,7 @@ alwaysApply: true
 ## 코드 구성
 - import 순서: 외부 라이브러리 → 내부 모듈 → 타입 import
 - 컴포넌트 내부 순서: 타입 정의 → 훅 사용 → 상태 기반 파생 상태 상수 → 이벤트 핸들러 → 렌더링
+- export default, function 기반 컴포넌트는 사용하지 않으며 const로 정의한다.
 
 ## 성능 최적화
 - 컴포넌트 분리를 통한 렌더링 최적화

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as UsersCreateRouteImport } from './routes/users/create/route'
 import { Route as TeamsCreateRouteImport } from './routes/teams/create/route'
 import { Route as MatchesEntryRouteImport } from './routes/matches/entry/route'
 import { Route as MatchesCreateRouteImport } from './routes/matches/create/route'
+import { Route as TeamsTeamIdSchedulesRouteImport } from './routes/teams/$teamId/schedules/route'
 import { Route as TeamsTeamIdPlayersRouteImport } from './routes/teams/$teamId/players/route'
 import { Route as TeamsTeamIdMatchesRouteImport } from './routes/teams/$teamId/matches/route'
 import { Route as MatchesMatchIdRecordRouteImport } from './routes/matches/$matchId/record/route'
@@ -58,6 +59,12 @@ const MatchesEntryRouteRoute = MatchesEntryRouteImport.update({
 const MatchesCreateRouteRoute = MatchesCreateRouteImport.update({
   id: '/matches/create',
   path: '/matches/create',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const TeamsTeamIdSchedulesRouteRoute = TeamsTeamIdSchedulesRouteImport.update({
+  id: '/teams/$teamId/schedules',
+  path: '/teams/$teamId/schedules',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -166,6 +173,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TeamsTeamIdPlayersRouteImport
       parentRoute: typeof rootRoute
     }
+    '/teams/$teamId/schedules': {
+      id: '/teams/$teamId/schedules'
+      path: '/teams/$teamId/schedules'
+      fullPath: '/teams/$teamId/schedules'
+      preLoaderRoute: typeof TeamsTeamIdSchedulesRouteImport
+      parentRoute: typeof rootRoute
+    }
     '/matches/$matchId/players/edit': {
       id: '/matches/$matchId/players/edit'
       path: '/matches/$matchId/players/edit'
@@ -189,6 +203,7 @@ export interface FileRoutesByFullPath {
   '/matches/$matchId/record': typeof MatchesMatchIdRecordRouteRoute
   '/teams/$teamId/matches': typeof TeamsTeamIdMatchesRouteRoute
   '/teams/$teamId/players': typeof TeamsTeamIdPlayersRouteRoute
+  '/teams/$teamId/schedules': typeof TeamsTeamIdSchedulesRouteRoute
   '/matches/$matchId/players/edit': typeof MatchesMatchIdPlayersEditRouteRoute
 }
 
@@ -203,6 +218,7 @@ export interface FileRoutesByTo {
   '/matches/$matchId/record': typeof MatchesMatchIdRecordRouteRoute
   '/teams/$teamId/matches': typeof TeamsTeamIdMatchesRouteRoute
   '/teams/$teamId/players': typeof TeamsTeamIdPlayersRouteRoute
+  '/teams/$teamId/schedules': typeof TeamsTeamIdSchedulesRouteRoute
   '/matches/$matchId/players/edit': typeof MatchesMatchIdPlayersEditRouteRoute
 }
 
@@ -218,6 +234,7 @@ export interface FileRoutesById {
   '/matches/$matchId/record': typeof MatchesMatchIdRecordRouteRoute
   '/teams/$teamId/matches': typeof TeamsTeamIdMatchesRouteRoute
   '/teams/$teamId/players': typeof TeamsTeamIdPlayersRouteRoute
+  '/teams/$teamId/schedules': typeof TeamsTeamIdSchedulesRouteRoute
   '/matches/$matchId/players/edit': typeof MatchesMatchIdPlayersEditRouteRoute
 }
 
@@ -234,6 +251,7 @@ export interface FileRouteTypes {
     | '/matches/$matchId/record'
     | '/teams/$teamId/matches'
     | '/teams/$teamId/players'
+    | '/teams/$teamId/schedules'
     | '/matches/$matchId/players/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -247,6 +265,7 @@ export interface FileRouteTypes {
     | '/matches/$matchId/record'
     | '/teams/$teamId/matches'
     | '/teams/$teamId/players'
+    | '/teams/$teamId/schedules'
     | '/matches/$matchId/players/edit'
   id:
     | '__root__'
@@ -260,6 +279,7 @@ export interface FileRouteTypes {
     | '/matches/$matchId/record'
     | '/teams/$teamId/matches'
     | '/teams/$teamId/players'
+    | '/teams/$teamId/schedules'
     | '/matches/$matchId/players/edit'
   fileRoutesById: FileRoutesById
 }
@@ -275,6 +295,7 @@ export interface RootRouteChildren {
   MatchesMatchIdRecordRouteRoute: typeof MatchesMatchIdRecordRouteRoute
   TeamsTeamIdMatchesRouteRoute: typeof TeamsTeamIdMatchesRouteRoute
   TeamsTeamIdPlayersRouteRoute: typeof TeamsTeamIdPlayersRouteRoute
+  TeamsTeamIdSchedulesRouteRoute: typeof TeamsTeamIdSchedulesRouteRoute
   MatchesMatchIdPlayersEditRouteRoute: typeof MatchesMatchIdPlayersEditRouteRoute
 }
 
@@ -289,6 +310,7 @@ const rootRouteChildren: RootRouteChildren = {
   MatchesMatchIdRecordRouteRoute: MatchesMatchIdRecordRouteRoute,
   TeamsTeamIdMatchesRouteRoute: TeamsTeamIdMatchesRouteRoute,
   TeamsTeamIdPlayersRouteRoute: TeamsTeamIdPlayersRouteRoute,
+  TeamsTeamIdSchedulesRouteRoute: TeamsTeamIdSchedulesRouteRoute,
   MatchesMatchIdPlayersEditRouteRoute: MatchesMatchIdPlayersEditRouteRoute,
 }
 
@@ -312,6 +334,7 @@ export const routeTree = rootRoute
         "/matches/$matchId/record",
         "/teams/$teamId/matches",
         "/teams/$teamId/players",
+        "/teams/$teamId/schedules",
         "/matches/$matchId/players/edit"
       ]
     },
@@ -344,6 +367,9 @@ export const routeTree = rootRoute
     },
     "/teams/$teamId/players": {
       "filePath": "teams/$teamId/players/route.tsx"
+    },
+    "/teams/$teamId/schedules": {
+      "filePath": "teams/$teamId/schedules/route.tsx"
     },
     "/matches/$matchId/players/edit": {
       "filePath": "matches/$matchId/players/edit/route.tsx"

--- a/src/routes/matches/$matchId/record/-components/PlayerSubstitutionConfirmModal/PlayerSubstitutionConfirmModal.tsx
+++ b/src/routes/matches/$matchId/record/-components/PlayerSubstitutionConfirmModal/PlayerSubstitutionConfirmModal.tsx
@@ -14,13 +14,13 @@ interface PlayerSubstitutionConfirmModalProps {
   isOpen: boolean;
 }
 
-export function PlayerSubstitutionConfirmModal({
+export const PlayerSubstitutionConfirmModal = ({
   outPlayer,
   inPlayer,
   onConfirm,
   onClose,
   isOpen,
-}: PlayerSubstitutionConfirmModalProps) {
+}: PlayerSubstitutionConfirmModalProps) => {
   if (!isOpen) {
     return null;
   }
@@ -68,7 +68,7 @@ export function PlayerSubstitutionConfirmModal({
       </div>
     </div>
   );
-}
+};
 
 const fallbackImageHandler = createFallbackImageHandler();
 

--- a/src/routes/teams/$teamId/index/-mock-data.ts
+++ b/src/routes/teams/$teamId/index/-mock-data.ts
@@ -7,7 +7,7 @@ import type {
   TeamInfo,
 } from './-temp-server-types';
 
-export function createTeamAndMatch(teamResponse: ApiResponse<TeamResponse>) {
+export const createTeamAndMatch = (teamResponse: ApiResponse<TeamResponse>) => {
   const teamInfo: TeamInfo = {
     name: teamResponse.data.name,
     description: `${teamResponse.data.name}의 팀 소개입니다.`,
@@ -99,7 +99,7 @@ export function createTeamAndMatch(teamResponse: ApiResponse<TeamResponse>) {
   ];
 
   return { teamInfo, matchResults };
-}
+};
 
 export const notices: Notice[] = [
   {

--- a/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/GoalList/GoalList.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/GoalList/GoalList.tsx
@@ -6,7 +6,7 @@ export interface GoalListProps {
   goals: Goal[];
 }
 
-export function GoalList({ goals }: GoalListProps) {
+export const GoalList = ({ goals }: GoalListProps) => {
   return (
     <div className={styles.rootContainer}>
       {goals.map((goal, index) => (
@@ -18,4 +18,4 @@ export function GoalList({ goals }: GoalListProps) {
       ))}
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchDetailLink/MatchDetailLink.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchDetailLink/MatchDetailLink.tsx
@@ -2,11 +2,11 @@ import { ChevronRightIcon } from '@/assets/icons';
 
 import * as styles from './MatchDetailLink.css';
 
-export function MatchDetailLink() {
+export const MatchDetailLink = () => {
   return (
     <button className={styles.container}>
       <div className={styles.text}>자세히 보기</div>
       <ChevronRightIcon className={styles.icon} />
     </button>
   );
-}
+};

--- a/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchDetailPanel.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchDetailPanel.tsx
@@ -24,7 +24,7 @@ export interface MatchDetailPanelProps {
   players: PlayerStat[];
 }
 
-export function MatchDetailPanel({
+export const MatchDetailPanel = ({
   homeTeam,
   awayTeam,
   goals,
@@ -34,7 +34,7 @@ export function MatchDetailPanel({
   date,
   location,
   players,
-}: MatchDetailPanelProps) {
+}: MatchDetailPanelProps) => {
   return (
     <div className={styles.rootContainer}>
       <div className={styles.infoContainer}>
@@ -61,4 +61,4 @@ export function MatchDetailPanel({
       />
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchHeader/MatchHeader.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchHeader/MatchHeader.tsx
@@ -7,7 +7,7 @@ export interface MatchHeaderProps {
   awayTeam: TeamData;
 }
 
-export function MatchHeader({ homeTeam, awayTeam }: MatchHeaderProps) {
+export const MatchHeader = ({ homeTeam, awayTeam }: MatchHeaderProps) => {
   return (
     <div className={styles.rootContainer}>
       <TeamInfo team={homeTeam} type='Home' />
@@ -23,7 +23,7 @@ export function MatchHeader({ homeTeam, awayTeam }: MatchHeaderProps) {
       <TeamInfo team={awayTeam} type='Away' />
     </div>
   );
-}
+};
 
 interface TeamInfoProps {
   team: TeamData;

--- a/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchMetadata/MatchMetadata.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchDetailPanel/MatchMetadata/MatchMetadata.tsx
@@ -8,13 +8,13 @@ export interface MatchMetadataProps {
   location: string;
 }
 
-export function MatchMetadata({
+export const MatchMetadata = ({
   duration,
   playersPlayed,
   totalPlayers,
   date,
   location,
-}: MatchMetadataProps) {
+}: MatchMetadataProps) => {
   return (
     <div className={styles.container}>
       <Row label='경기 시간' value={`${duration}분`} />
@@ -23,7 +23,7 @@ export function MatchMetadata({
       <Row label='장소' value={location} />
     </div>
   );
-}
+};
 
 const Row = ({ label, value }: { label: string; value: string }) => {
   return (

--- a/src/routes/teams/$teamId/matches/-components/MatchFilters.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchFilters.tsx
@@ -8,7 +8,7 @@ interface MatchFiltersProps {
   className?: string;
 }
 
-export function MatchFilters({ className }: MatchFiltersProps) {
+export const MatchFilters = ({ className }: MatchFiltersProps) => {
   return (
     <div className={clsx(styles.container, className)}>
       <div className={styles.searchContainer}>
@@ -56,4 +56,4 @@ export function MatchFilters({ className }: MatchFiltersProps) {
       </div>
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/matches/-components/MatchTable.tsx
+++ b/src/routes/teams/$teamId/matches/-components/MatchTable.tsx
@@ -19,11 +19,11 @@ interface MatchTableProps {
   className?: string;
 }
 
-export function MatchTable({
+export const MatchTable = ({
   matches,
   onMatchClick,
   headerActions,
-}: MatchTableProps) {
+}: MatchTableProps) => {
   const columns = {
     type: {
       key: 'type',
@@ -103,4 +103,4 @@ export function MatchTable({
       className={styles.tableOverride}
     />
   );
-}
+};

--- a/src/routes/teams/$teamId/matches/-components/TeamStatsSummary.tsx
+++ b/src/routes/teams/$teamId/matches/-components/TeamStatsSummary.tsx
@@ -9,10 +9,10 @@ interface TeamStatsSummaryProps {
   className?: string;
 }
 
-export function TeamStatsSummary({
+export const TeamStatsSummary = ({
   teamStats,
   className,
-}: TeamStatsSummaryProps) {
+}: TeamStatsSummaryProps) => {
   return (
     <div className={clsx(styles.rootContainer, className)}>
       <div className={styles.teamInfoContainer}>
@@ -72,4 +72,4 @@ export function TeamStatsSummary({
       </div>
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/players/-components/MemberFilters/MemberFilters.tsx
+++ b/src/routes/teams/$teamId/players/-components/MemberFilters/MemberFilters.tsx
@@ -33,12 +33,12 @@ interface MemberFiltersProps {
   onDateFilter?: (date: string) => void;
 }
 
-export function MemberFilters({
+export const MemberFilters = ({
   onSearchChange,
   onPositionFilter,
   onFootFilter,
   onDateFilter,
-}: MemberFiltersProps) {
+}: MemberFiltersProps) => {
   const [searchValue, setSearchValue] = useState('');
   const [positionValue, setPositionValue] = useState('');
   const [footValue, setFootValue] = useState('');
@@ -99,4 +99,4 @@ export function MemberFilters({
       </div>
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/players/-components/MemberStatsSummary/MemberStatsSummary.tsx
+++ b/src/routes/teams/$teamId/players/-components/MemberStatsSummary/MemberStatsSummary.tsx
@@ -14,10 +14,10 @@ const defaultPositionStats: PositionStat[] = [
   { position: 'GK', count: 6 },
 ];
 
-export function MemberStatsSummary({
+export const MemberStatsSummary = ({
   totalMembers = 54,
   positionStats = defaultPositionStats,
-}: MemberStatsSummaryProps) {
+}: MemberStatsSummaryProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.totalMembersSection}>
@@ -39,4 +39,4 @@ export function MemberStatsSummary({
       </div>
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/players/-components/PlayerDetailPanel/MatchRecordTable.tsx
+++ b/src/routes/teams/$teamId/players/-components/PlayerDetailPanel/MatchRecordTable.tsx
@@ -77,7 +77,7 @@ const columns = {
   },
 } satisfies TableColumnsDefinition<MatchRecord>;
 
-export function MatchRecordTable({ matchRecords }: MatchRecordTableProps) {
+export const MatchRecordTable = ({ matchRecords }: MatchRecordTableProps) => {
   return (
     <Table
       columns={columns}
@@ -87,4 +87,4 @@ export function MatchRecordTable({ matchRecords }: MatchRecordTableProps) {
       className={styles.matchRecordTable}
     />
   );
-}
+};

--- a/src/routes/teams/$teamId/players/-components/PlayerDetailPanel/PlayerDetailPanel.tsx
+++ b/src/routes/teams/$teamId/players/-components/PlayerDetailPanel/PlayerDetailPanel.tsx
@@ -12,14 +12,14 @@ export interface PlayerDetailPanelProps {
   matchRecords: MatchRecord[];
 }
 
-export function PlayerDetailPanel({
+export const PlayerDetailPanel = ({
   member,
   matchRecords,
-}: PlayerDetailPanelProps) {
+}: PlayerDetailPanelProps) => {
   return (
     <div className={styles.rootContainer}>
       <PlayerProfile member={member} />
       <MatchRecordTable matchRecords={matchRecords} />
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/players/-components/PlayerDetailPanel/PlayerProfile.tsx
+++ b/src/routes/teams/$teamId/players/-components/PlayerDetailPanel/PlayerProfile.tsx
@@ -12,7 +12,7 @@ export interface PlayerProfileProps {
   member: Member;
 }
 
-export function PlayerProfile({ member }: PlayerProfileProps) {
+export const PlayerProfile = ({ member }: PlayerProfileProps) => {
   return (
     <div className={styles.rootContainer}>
       <div className={styles.profileSection}>
@@ -60,4 +60,4 @@ export function PlayerProfile({ member }: PlayerProfileProps) {
       </div>
     </div>
   );
-}
+};

--- a/src/routes/teams/$teamId/schedules/-components/CalendarGrid.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarGrid.css.ts
@@ -1,0 +1,145 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+// 이벤트 배경색 상수
+const EVENT_COLORS = {
+  league: lightThemeVars.color.primary[300],
+  friendly: 'rgba(255, 232, 219, 1)',
+  other: 'rgba(219, 255, 229, 1)',
+  hoverPrimary: 'rgba(0, 67, 255, 0.05)',
+} as const;
+
+export const gridContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  marginTop: 14,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.black,
+  fontSize: 16,
+  fontWeight: 500,
+});
+
+export const row = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const weekHeaderCell = style({
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '23px 10px',
+  width: 128,
+  height: 100,
+});
+
+export const weekHeaderText = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginTop: 4,
+  borderRadius: 100,
+  width: 44,
+  minHeight: 44,
+  color: lightThemeVars.color.black,
+});
+
+export const dayInactive = style({
+  color: lightThemeVars.color.gray[500],
+});
+
+export const dayCell = style({
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 1,
+  alignItems: 'center',
+  transition: 'background-color 0.2s ease',
+  cursor: 'pointer',
+  padding: '23px 10px',
+  width: 128,
+  height: 100,
+  overflow: 'hidden',
+  ':hover': {
+    borderRadius: 8,
+    backgroundColor: EVENT_COLORS.hoverPrimary,
+  },
+});
+
+export const dayCellWithEvents = style({
+  backgroundColor: lightThemeVars.color.white.main,
+  padding: '9px 10px',
+  letterSpacing: -0.3,
+  fontSize: 12,
+  fontWeight: 400,
+});
+
+export const dayNumber = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginTop: 4,
+  borderRadius: '50%',
+  width: 20,
+  height: 20,
+  letterSpacing: -0.4,
+  fontSize: 16,
+  fontWeight: 500,
+});
+
+export const eventListContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  overflowY: 'auto',
+});
+
+export const dayNumberInactive = style({
+  color: lightThemeVars.color.gray[500],
+});
+
+export const dayNumberToday = style({
+  color: lightThemeVars.color.primary[700],
+  fontWeight: 600,
+});
+
+export const dayNumberSelected = style({
+  backgroundColor: lightThemeVars.color.primary[700],
+  color: lightThemeVars.color.white.main,
+});
+
+export const eventIndicators = style({
+  display: 'flex',
+  gap: 6,
+  minHeight: 6,
+});
+
+export const eventItem = style({
+  display: '-webkit-box',
+  flexShrink: 0,
+  borderRadius: 4,
+  padding: '0 4px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  letterSpacing: -0.3,
+  color: lightThemeVars.color.black,
+  fontSize: 12,
+  fontWeight: 400,
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 1,
+});
+
+export const eventLeague = style({
+  backgroundColor: EVENT_COLORS.league,
+});
+
+export const eventFriendly = style({
+  backgroundColor: EVENT_COLORS.friendly,
+});
+
+export const eventOther = style({
+  backgroundColor: EVENT_COLORS.other,
+});

--- a/src/routes/teams/$teamId/schedules/-components/CalendarGrid.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarGrid.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { getMockCalendarData } from '@/routes/teams/$teamId/schedules/-mock-data';
 
-import CalendarGrid from './CalendarGrid';
+import { CalendarGrid } from './CalendarGrid';
 
 const meta = {
   title: 'Routes/Teams/Schedules/CalendarGrid',

--- a/src/routes/teams/$teamId/schedules/-components/CalendarGrid.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarGrid.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { getMockCalendarData } from '@/routes/teams/$teamId/schedules/-mock-data';
+
+import CalendarGrid from './CalendarGrid';
+
+const meta = {
+  title: 'Routes/Teams/Schedules/CalendarGrid',
+  component: CalendarGrid,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '캘린더의 날짜 그리드를 표시하는 컴포넌트입니다. 날짜 클릭과 일정 표시 기능을 제공합니다.',
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '952px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    days: { control: 'object' },
+    filters: { control: 'object' },
+    onDateSelect: { action: 'date selected' },
+    year: { control: 'number' },
+    month: { control: { type: 'range', min: 1, max: 12 } },
+  },
+} satisfies Meta<typeof CalendarGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    ...getMockCalendarData('2025-02-11'),
+    onDateSelect: (date: string, dayNumber: number) => {
+      console.log('Selected date:', date, 'Day:', dayNumber);
+    },
+  },
+};

--- a/src/routes/teams/$teamId/schedules/-components/CalendarGrid.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarGrid.tsx
@@ -37,6 +37,60 @@ const formatDateString = (year: number, month: number, dayNumber: number) => {
   return `${year}-${month.toString().padStart(2, '0')}-${dayNumber.toString().padStart(2, '0')}`;
 };
 
+interface CalendarGridProps {
+  days: CalendarDay[];
+  filters: ScheduleFilter[];
+  onDateSelect: (date: string, dayNumber: number) => void;
+  year: number;
+  month: number;
+}
+
+export const CalendarGrid = ({
+  days,
+  filters,
+  onDateSelect,
+  year,
+  month,
+}: CalendarGridProps) => {
+  const weeks = Array.from({ length: Math.ceil(days.length / 7) }, (_, index) =>
+    days.slice(index * 7, (index + 1) * 7),
+  );
+
+  return (
+    <div className={styles.gridContainer}>
+      <div className={styles.row}>
+        {weekDays.map(day => (
+          <div key={day} className={styles.weekHeaderCell}>
+            <div className={styles.eventIndicators} />
+            <div className={styles.weekHeaderText}>{day}</div>
+          </div>
+        ))}
+      </div>
+      {weeks.map((week, weekIndex) => {
+        const isInactiveWeek = week.every(day => !day.isCurrentMonth);
+
+        return (
+          <div
+            key={weekIndex}
+            className={clsx(styles.row, isInactiveWeek && styles.dayInactive)}
+          >
+            {week.map((day, dayIndex) =>
+              renderDayCell(
+                day,
+                weekIndex * 7 + dayIndex,
+                filters,
+                year,
+                month,
+                onDateSelect,
+              ),
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
 const renderDayCell = (
   day: CalendarDay,
   index: number,
@@ -90,59 +144,3 @@ const renderDayCell = (
     </div>
   );
 };
-
-interface CalendarGridProps {
-  days: CalendarDay[];
-  filters: ScheduleFilter[];
-  onDateSelect: (date: string, dayNumber: number) => void;
-  year: number;
-  month: number;
-}
-
-const CalendarGrid = ({
-  days,
-  filters,
-  onDateSelect,
-  year,
-  month,
-}: CalendarGridProps) => {
-  const weeks = Array.from({ length: Math.ceil(days.length / 7) }, (_, index) =>
-    days.slice(index * 7, (index + 1) * 7),
-  );
-
-  return (
-    <div className={styles.gridContainer}>
-      <div className={styles.row}>
-        {weekDays.map(day => (
-          <div key={day} className={styles.weekHeaderCell}>
-            <div className={styles.eventIndicators} />
-            <div className={styles.weekHeaderText}>{day}</div>
-          </div>
-        ))}
-      </div>
-      {weeks.map((week, weekIndex) => {
-        const isInactiveWeek = week.every(day => !day.isCurrentMonth);
-
-        return (
-          <div
-            key={weekIndex}
-            className={clsx(styles.row, isInactiveWeek && styles.dayInactive)}
-          >
-            {week.map((day, dayIndex) =>
-              renderDayCell(
-                day,
-                weekIndex * 7 + dayIndex,
-                filters,
-                year,
-                month,
-                onDateSelect,
-              ),
-            )}
-          </div>
-        );
-      })}
-    </div>
-  );
-};
-
-export default CalendarGrid;

--- a/src/routes/teams/$teamId/schedules/-components/CalendarGrid.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarGrid.tsx
@@ -1,0 +1,148 @@
+import clsx from 'clsx';
+
+import type {
+  CalendarDay,
+  ScheduleFilter,
+} from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+import * as styles from './CalendarGrid.css';
+
+const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
+
+const getEventClassName = (category: string) => {
+  switch (category) {
+    case '대회/리그':
+      return styles.eventLeague;
+    case '친선 매치':
+      return styles.eventFriendly;
+    case '기타':
+      return styles.eventOther;
+    default:
+      return styles.eventOther;
+  }
+};
+
+const filterVisibleSchedules = (
+  day: CalendarDay,
+  filters: ScheduleFilter[],
+) => {
+  return day.schedules.filter(schedule => {
+    const filter = filters.find(f => f.category === schedule.category);
+
+    return filter?.isActive ?? true;
+  });
+};
+
+const formatDateString = (year: number, month: number, dayNumber: number) => {
+  return `${year}-${month.toString().padStart(2, '0')}-${dayNumber.toString().padStart(2, '0')}`;
+};
+
+const renderDayCell = (
+  day: CalendarDay,
+  index: number,
+  filters: ScheduleFilter[],
+  year: number,
+  month: number,
+  onDateSelect: (date: string, dayNumber: number) => void,
+) => {
+  const visibleSchedules = filterVisibleSchedules(day, filters);
+  const hasEvents = visibleSchedules.length > 0 && day.isCurrentMonth;
+
+  const handleClick = () => {
+    if (day.isCurrentMonth) {
+      const dateString = formatDateString(year, month, day.date);
+      onDateSelect(dateString, day.date);
+    }
+  };
+
+  return (
+    <div
+      key={index}
+      className={clsx({
+        [styles.dayCell]: true,
+        [styles.dayCellWithEvents]: hasEvents,
+      })}
+      onClick={handleClick}
+    >
+      <div
+        className={clsx(
+          styles.dayNumber,
+          day.isToday && styles.dayNumberToday,
+          day.isSelected && styles.dayNumberSelected,
+          !day.isCurrentMonth && styles.dayNumberInactive,
+        )}
+      >
+        {day.date}
+      </div>
+      <div className={styles.eventListContainer}>
+        {visibleSchedules.map(schedule => (
+          <div
+            key={schedule.id}
+            className={clsx(
+              styles.eventItem,
+              getEventClassName(schedule.category),
+            )}
+          >
+            {schedule.startTime} {schedule.title}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+interface CalendarGridProps {
+  days: CalendarDay[];
+  filters: ScheduleFilter[];
+  onDateSelect: (date: string, dayNumber: number) => void;
+  year: number;
+  month: number;
+}
+
+const CalendarGrid = ({
+  days,
+  filters,
+  onDateSelect,
+  year,
+  month,
+}: CalendarGridProps) => {
+  const weeks = Array.from({ length: Math.ceil(days.length / 7) }, (_, index) =>
+    days.slice(index * 7, (index + 1) * 7),
+  );
+
+  return (
+    <div className={styles.gridContainer}>
+      <div className={styles.row}>
+        {weekDays.map(day => (
+          <div key={day} className={styles.weekHeaderCell}>
+            <div className={styles.eventIndicators} />
+            <div className={styles.weekHeaderText}>{day}</div>
+          </div>
+        ))}
+      </div>
+      {weeks.map((week, weekIndex) => {
+        const isInactiveWeek = week.every(day => !day.isCurrentMonth);
+
+        return (
+          <div
+            key={weekIndex}
+            className={clsx(styles.row, isInactiveWeek && styles.dayInactive)}
+          >
+            {week.map((day, dayIndex) =>
+              renderDayCell(
+                day,
+                weekIndex * 7 + dayIndex,
+                filters,
+                year,
+                month,
+                onDateSelect,
+              ),
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CalendarGrid;

--- a/src/routes/teams/$teamId/schedules/-components/CalendarHeader.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarHeader.css.ts
@@ -1,0 +1,85 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const headerContainer = style({
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '13px 28px',
+  width: '100%',
+});
+
+export const monthNavigation = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'start',
+  gap: 40,
+  letterSpacing: -0.7,
+  fontSize: 28,
+  fontWeight: 600,
+});
+
+export const navButton = style({
+  aspectRatio: 1,
+  cursor: 'pointer',
+  width: 24,
+  color: lightThemeVars.color.black,
+});
+
+export const monthText = style({
+  color: lightThemeVars.color.primary[700],
+});
+
+export const filtersContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  minWidth: 240,
+  minHeight: 42,
+  letterSpacing: -0.35,
+  fontSize: 14,
+});
+
+export const filterTag = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 4,
+  transition: 'all 0.2s ease',
+  borderRadius: 90,
+  backgroundColor: lightThemeVars.color.primary[300],
+  cursor: 'pointer',
+  padding: '10px 16px',
+  ':hover': {
+    backgroundColor: 'rgba(200, 215, 255, 1)',
+  },
+});
+
+export const filterTagInactive = style({
+  backgroundColor: lightThemeVars.color.gray[200],
+  ':hover': {
+    backgroundColor: lightThemeVars.color.gray[300],
+  },
+});
+
+export const filterLabel = style({
+  color: lightThemeVars.color.primary[700],
+  fontWeight: 500,
+});
+
+export const filterLabelInactive = style({
+  color: lightThemeVars.color.gray[500],
+});
+
+export const filterCount = style({
+  width: 17,
+  textAlign: 'right',
+  color: lightThemeVars.color.primary[700],
+  fontWeight: 600,
+});
+
+export const filterCountInactive = style({
+  color: lightThemeVars.color.gray[500],
+});

--- a/src/routes/teams/$teamId/schedules/-components/CalendarHeader.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarHeader.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CalendarHeader from './CalendarHeader';
+
+const meta = {
+  title: 'Routes/Teams/Schedules/CalendarHeader',
+  component: CalendarHeader,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '캘린더의 헤더 영역을 담당하는 컴포넌트입니다. 월 네비게이션과 필터 기능을 제공합니다.',
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '952px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    year: { control: 'number' },
+    month: { control: { type: 'range', min: 1, max: 12 } },
+    filters: { control: 'object' },
+    onPreviousMonth: { action: 'previous month clicked' },
+    onNextMonth: { action: 'next month clicked' },
+    onFilterToggle: { action: 'filter toggled' },
+  },
+} satisfies Meta<typeof CalendarHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    year: 2025,
+    month: 2,
+    filters: [
+      { category: '대회/리그', count: 11, isActive: true },
+      { category: '친선 매치', count: 3, isActive: true },
+      { category: '기타', count: 6, isActive: true },
+    ],
+    onPreviousMonth: () => {},
+    onNextMonth: () => {},
+    onFilterToggle: () => {},
+  },
+};

--- a/src/routes/teams/$teamId/schedules/-components/CalendarHeader.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarHeader.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import CalendarHeader from './CalendarHeader';
+import { CalendarHeader } from './CalendarHeader';
 
 const meta = {
   title: 'Routes/Teams/Schedules/CalendarHeader',

--- a/src/routes/teams/$teamId/schedules/-components/CalendarHeader.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarHeader.tsx
@@ -1,0 +1,83 @@
+import clsx from 'clsx';
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@/assets/icons';
+import type { ScheduleFilter } from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+import * as styles from './CalendarHeader.css';
+
+const monthNames = [
+  '1월',
+  '2월',
+  '3월',
+  '4월',
+  '5월',
+  '6월',
+  '7월',
+  '8월',
+  '9월',
+  '10월',
+  '11월',
+  '12월',
+];
+
+interface CalendarHeaderProps {
+  year: number;
+  month: number;
+  filters: ScheduleFilter[];
+  onPreviousMonth: () => void;
+  onNextMonth: () => void;
+  onFilterToggle: (category: string) => void;
+}
+
+function CalendarHeader({
+  year,
+  month,
+  filters,
+  onPreviousMonth,
+  onNextMonth,
+  onFilterToggle,
+}: CalendarHeaderProps) {
+  return (
+    <div className={styles.headerContainer}>
+      <div className={styles.monthNavigation}>
+        <ChevronLeftIcon
+          className={styles.navButton}
+          onClick={onPreviousMonth}
+        />
+        <div className={styles.monthText}>{monthNames[month - 1]}</div>
+        <ChevronRightIcon className={styles.navButton} onClick={onNextMonth} />
+      </div>
+      <div className={styles.filtersContainer}>
+        {filters.map(filter => (
+          <div
+            key={filter.category}
+            className={clsx(
+              styles.filterTag,
+              !filter.isActive && styles.filterTagInactive,
+            )}
+            onClick={() => onFilterToggle(filter.category)}
+          >
+            <div
+              className={clsx(
+                styles.filterLabel,
+                !filter.isActive && styles.filterLabelInactive,
+              )}
+            >
+              {filter.category}
+            </div>
+            <div
+              className={clsx(
+                styles.filterCount,
+                !filter.isActive && styles.filterCountInactive,
+              )}
+            >
+              {filter.count}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default CalendarHeader;

--- a/src/routes/teams/$teamId/schedules/-components/CalendarHeader.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/CalendarHeader.tsx
@@ -29,14 +29,13 @@ interface CalendarHeaderProps {
   onFilterToggle: (category: string) => void;
 }
 
-function CalendarHeader({
-  year,
+export const CalendarHeader = ({
   month,
   filters,
   onPreviousMonth,
   onNextMonth,
   onFilterToggle,
-}: CalendarHeaderProps) {
+}: CalendarHeaderProps) => {
   return (
     <div className={styles.headerContainer}>
       <div className={styles.monthNavigation}>
@@ -78,6 +77,4 @@ function CalendarHeader({
       </div>
     </div>
   );
-}
-
-export default CalendarHeader;
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.css.ts
@@ -1,0 +1,14 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const calendarContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: 10,
+  boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
+  backgroundColor: lightThemeVars.color.white.main,
+  padding: '20px 0 24px',
+  width: '100%',
+  lineHeight: 1.4,
+});

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { getMockCalendarData } from '@/routes/teams/$teamId/schedules/-mock-data';
+
+import ScheduleCalendar from './ScheduleCalendar';
+
+const meta = {
+  title: 'Routes/Teams/Schedules/ScheduleCalendar',
+  component: ScheduleCalendar,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '전체 캘린더를 표시하는 메인 컴포넌트입니다. 헤더와 그리드를 포함하며 날짜 선택과 필터링 기능을 제공합니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    data: { control: 'object' },
+    onDateSelect: { action: 'date selected' },
+    onMonthChange: { action: 'month changed' },
+    onFilterToggle: { action: 'filter toggled' },
+  },
+  decorators: [
+    Story => (
+      <div style={{ padding: '20px', maxWidth: '1000px', margin: '0 auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ScheduleCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    data: getMockCalendarData('2025-02-11'),
+    onDateSelect: () => {},
+    onMonthChange: () => {},
+    onFilterToggle: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 상태의 캘린더입니다. 2월 11일이 선택되어 있습니다.',
+      },
+    },
+  },
+};
+
+export const EmptyMonth: Story = {
+  args: {
+    data: {
+      year: 2025,
+      month: 3,
+      days: Array.from({ length: 42 }, (_, i) => ({
+        date: (i % 31) + 1,
+        isCurrentMonth: i >= 6 && i < 37,
+        isToday: false,
+        isSelected: false,
+        schedules: [],
+      })),
+      filters: [
+        { category: '대회/리그', count: 0, isActive: true },
+        { category: '친선 매치', count: 0, isActive: true },
+        { category: '기타', count: 0, isActive: true },
+      ],
+    },
+    onDateSelect: () => {},
+    onMonthChange: () => {},
+    onFilterToggle: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '일정이 없는 3월의 캘린더입니다.',
+      },
+    },
+  },
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { getMockCalendarData } from '@/routes/teams/$teamId/schedules/-mock-data';
 
-import ScheduleCalendar from './ScheduleCalendar';
+import { ScheduleCalendar } from './ScheduleCalendar';
 
 const meta = {
   title: 'Routes/Teams/Schedules/ScheduleCalendar',

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.tsx
@@ -1,7 +1,7 @@
 import type { CalendarData } from '@/routes/teams/$teamId/schedules/-temp-server-types';
 
-import CalendarGrid from './CalendarGrid';
-import CalendarHeader from './CalendarHeader';
+import { CalendarGrid } from './CalendarGrid';
+import { CalendarHeader } from './CalendarHeader';
 import * as styles from './ScheduleCalendar.css';
 
 interface ScheduleCalendarProps {
@@ -11,7 +11,7 @@ interface ScheduleCalendarProps {
   onFilterToggle: (category: string) => void;
 }
 
-const ScheduleCalendar = ({
+export const ScheduleCalendar = ({
   data,
   onDateSelect,
   onMonthChange,
@@ -61,5 +61,3 @@ const ScheduleCalendar = ({
     </div>
   );
 };
-
-export default ScheduleCalendar;

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCalendar.tsx
@@ -1,0 +1,65 @@
+import type { CalendarData } from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+import CalendarGrid from './CalendarGrid';
+import CalendarHeader from './CalendarHeader';
+import * as styles from './ScheduleCalendar.css';
+
+interface ScheduleCalendarProps {
+  data: CalendarData;
+  onDateSelect: (date: string, dayNumber: number) => void;
+  onMonthChange: (year: number, month: number) => void;
+  onFilterToggle: (category: string) => void;
+}
+
+const ScheduleCalendar = ({
+  data,
+  onDateSelect,
+  onMonthChange,
+  onFilterToggle,
+}: ScheduleCalendarProps) => {
+  const handlePreviousMonth = () => {
+    let newYear = data.year;
+    let newMonth = data.month - 1;
+
+    if (newMonth < 1) {
+      newMonth = 12;
+      newYear -= 1;
+    }
+
+    onMonthChange(newYear, newMonth);
+  };
+
+  const handleNextMonth = () => {
+    let newYear = data.year;
+    let newMonth = data.month + 1;
+
+    if (newMonth > 12) {
+      newMonth = 1;
+      newYear += 1;
+    }
+
+    onMonthChange(newYear, newMonth);
+  };
+
+  return (
+    <div className={styles.calendarContainer}>
+      <CalendarHeader
+        year={data.year}
+        month={data.month}
+        filters={data.filters}
+        onPreviousMonth={handlePreviousMonth}
+        onNextMonth={handleNextMonth}
+        onFilterToggle={onFilterToggle}
+      />
+      <CalendarGrid
+        days={data.days}
+        filters={data.filters}
+        onDateSelect={onDateSelect}
+        year={data.year}
+        month={data.month}
+      />
+    </div>
+  );
+};
+
+export default ScheduleCalendar;

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCreateForm.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCreateForm.css.ts
@@ -1,0 +1,142 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: 10,
+  backgroundColor: lightThemeVars.color.white.main,
+  width: '100%',
+  height: '100%',
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderTopLeftRadius: 10,
+  borderTopRightRadius: 10,
+  backgroundColor: lightThemeVars.color.primary[800],
+  padding: '25px 20px',
+});
+
+export const headerContent = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+export const titleSection = style({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const title = style({
+  margin: 0,
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.white.main,
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const cancelButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  border: 'none',
+  borderRadius: 8,
+  backgroundColor: 'transparent',
+  cursor: 'pointer',
+  padding: 0,
+});
+
+export const cancelIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 24,
+  height: 24,
+  color: lightThemeVars.color.primary[400],
+});
+
+export const cancelText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.primary[400],
+  fontSize: 14,
+  fontWeight: 600,
+});
+
+export const content = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 8,
+  marginTop: 20,
+  padding: '20px 16px',
+});
+
+export const field = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+});
+
+export const textarea = style({
+  boxSizing: 'border-box',
+  outline: 'none',
+  border: `1px solid ${lightThemeVars.color.primary[100]}`,
+  borderRadius: 6,
+  backgroundColor: lightThemeVars.color.white.hover,
+  padding: '9px 16px',
+  width: '100%',
+  minHeight: 200,
+  resize: 'none',
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.black,
+  fontSize: 14,
+  fontWeight: 400,
+  '::placeholder': {
+    color: lightThemeVars.color.gray[300],
+  },
+});
+
+export const submitButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 8,
+  border: 'none',
+  borderRadius: 8,
+  boxShadow: '4px 4px 8px 0px rgba(0,0,0,0.05)',
+  backgroundColor: lightThemeVars.color.primary[700],
+  height: 44,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.white.main,
+  fontSize: 14,
+  fontWeight: 600,
+  ':hover': {
+    backgroundColor: lightThemeVars.color.primary['700Darken'],
+  },
+});
+
+export const submitIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 24,
+  height: 24,
+  color: lightThemeVars.color.white.main,
+});
+
+export const submitText = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.white.main,
+  fontSize: 14,
+  fontWeight: 600,
+});

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCreateForm.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCreateForm.tsx
@@ -28,7 +28,7 @@ const scheduleFormSchema = z.object({
   description: z.string().optional(),
 });
 
-type ScheduleFormData = z.infer<typeof scheduleFormSchema>;
+export type ScheduleFormData = z.infer<typeof scheduleFormSchema>;
 
 const generateTimeOptions = () => {
   return Array.from({ length: 24 }, (_, hour) =>

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleCreateForm.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleCreateForm.tsx
@@ -1,0 +1,186 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { CalendarIcon, PlusIcon, XIcon } from '@/assets/icons';
+import {
+  ErrorMessage,
+  Input,
+  InputWithIcon,
+  Label,
+  Select,
+} from '@/components';
+import { TimeSelect } from '@/routes/matches/create/-components/TimeSelect';
+
+import * as styles from './ScheduleCreateForm.css';
+
+interface ScheduleCreateFormProps {
+  selectedDate: string;
+  onCancel: () => void;
+  onSubmit: (formData: ScheduleFormData) => void;
+}
+
+const scheduleFormSchema = z.object({
+  title: z.string().min(1, '일정 이름을 입력해주세요.'),
+  date: z.string().min(1, '날짜를 입력해주세요.'),
+  startTime: z.string().min(1, '시작 시간을 입력해주세요.'),
+  endTime: z.string().min(1, '종료 시간을 입력해주세요.'),
+  description: z.string().optional(),
+});
+
+type ScheduleFormData = z.infer<typeof scheduleFormSchema>;
+
+const generateTimeOptions = () => {
+  return Array.from({ length: 24 }, (_, hour) =>
+    Array.from({ length: 2 }, (_, minuteIndex) => {
+      const minute = minuteIndex * 30;
+      const timeString = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
+
+      return {
+        value: timeString,
+        label: timeString,
+      };
+    }),
+  ).flat();
+};
+
+export const ScheduleCreateForm = ({
+  selectedDate,
+  onCancel,
+  onSubmit,
+}: ScheduleCreateFormProps) => {
+  const timeOptions = generateTimeOptions();
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<ScheduleFormData>({
+    resolver: zodResolver(scheduleFormSchema),
+    defaultValues: {
+      title: '',
+      date: selectedDate,
+      startTime: '12:30',
+      endTime: '14:30',
+      description: '',
+    },
+  });
+
+  const onFormSubmit = (data: ScheduleFormData) => {
+    onSubmit(data);
+  };
+
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.header}>
+        <div className={styles.headerContent}>
+          <div className={styles.titleSection}>
+            <h2 className={styles.title}>일정 등록</h2>
+          </div>
+          <button className={styles.cancelButton} onClick={onCancel}>
+            <div className={styles.cancelIcon}>
+              <XIcon />
+            </div>
+            <span className={styles.cancelText}>화면 닫기</span>
+          </button>
+        </div>
+      </div>
+
+      <form
+        id='schedule-form'
+        className={styles.content}
+        onSubmit={handleSubmit(onFormSubmit)}
+      >
+        <div className={styles.field}>
+          <Label label='일정 이름' required>
+            <Input
+              placeholder='단체 축구 훈련'
+              isError={!!errors.title}
+              {...register('title')}
+            />
+            <ErrorMessage>{errors.title?.message}</ErrorMessage>
+          </Label>
+        </div>
+
+        <div className={styles.field}>
+          <Label label='날짜' required>
+            <InputWithIcon
+              placeholder='날짜를 선택해주세요.'
+              isError={!!errors.date}
+              {...register('date')}
+              type='date'
+              icon={<CalendarIcon />}
+              variant='gray-small'
+            />
+            <ErrorMessage>{errors.date?.message}</ErrorMessage>
+          </Label>
+        </div>
+
+        <div className={styles.field}>
+          <Label label='시간' required>
+            <TimeSelect
+              startTimeSelect={
+                <Controller
+                  name='startTime'
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      options={timeOptions}
+                      placeholder='-- : --'
+                      value={field.value}
+                      onChange={field.onChange}
+                      isError={!!errors.startTime}
+                      variant='gray-small'
+                    />
+                  )}
+                />
+              }
+              endTimeSelect={
+                <Controller
+                  name='endTime'
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      options={timeOptions}
+                      placeholder='-- : --'
+                      value={field.value}
+                      onChange={field.onChange}
+                      isError={!!errors.endTime}
+                      variant='gray-small'
+                    />
+                  )}
+                />
+              }
+            />
+            <ErrorMessage>
+              {errors.startTime?.message || errors.endTime?.message}
+            </ErrorMessage>
+          </Label>
+        </div>
+
+        <div className={styles.field} style={{ flex: 1 }}>
+          <Label label='일정 세부사항'>
+            <textarea
+              className={styles.textarea}
+              placeholder='내용을 입력해주세요'
+              rows={8}
+              {...register('description')}
+            />
+            <ErrorMessage>{errors.description?.message}</ErrorMessage>
+          </Label>
+        </div>
+        <button
+          className={styles.submitButton}
+          type='submit'
+          form='schedule-form'
+        >
+          <div className={styles.submitIcon}>
+            <PlusIcon />
+          </div>
+          일정 생성하기
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.css.ts
@@ -9,6 +9,7 @@ export const rootContainer = style({
   boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
   backgroundColor: lightThemeVars.color.white.main,
   width: 362,
+  height: '100%',
 });
 
 export const headerContainer = style({
@@ -123,8 +124,8 @@ export const scheduleListContainer = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 20,
-  height: 692,
-  overflow: 'clip',
+  height: 672,
+  overflowY: 'auto',
 });
 
 export const emptyState = style({

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.css.ts
@@ -1,0 +1,138 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: 10,
+  boxShadow: '4px 4px 8px 0px rgba(0, 0, 0, 0.05)',
+  backgroundColor: lightThemeVars.color.white.main,
+  width: 362,
+});
+
+export const headerContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '10px 10px 0 0',
+  backgroundColor: lightThemeVars.color.primary[800],
+  padding: 20,
+});
+
+export const headerContent = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 10,
+  width: '100%',
+});
+
+export const dateSection = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const dateText = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  lineHeight: 1.4,
+  letterSpacing: -0.6,
+  color: lightThemeVars.color.white.main,
+  fontSize: 24,
+  fontWeight: 500,
+});
+
+export const monthText = style({
+  color: lightThemeVars.color.white.main,
+});
+
+export const dayText = style({
+  color: lightThemeVars.color.white.main,
+});
+
+export const dayOfWeek = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '0 8px',
+  height: 34,
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.primary[300],
+  fontSize: 16,
+  fontWeight: 500,
+});
+
+export const createButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 4,
+  border: 'none',
+  cursor: 'pointer',
+  height: 24,
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.primary[300],
+  fontSize: 14,
+  fontWeight: 600,
+  ':hover': {
+    color: lightThemeVars.color.white.main,
+  },
+});
+
+export const createIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 12,
+  height: 12,
+});
+
+export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 20,
+  padding: '20px 16px',
+});
+
+export const scheduleHeader = style({
+  display: 'flex',
+  alignItems: 'end',
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const scheduleLabel = style({
+  color: lightThemeVars.color.gray[500],
+});
+
+export const scheduleCount = style({
+  padding: '0 10px',
+  color: lightThemeVars.color.black,
+  fontWeight: 600,
+});
+
+export const scheduleListContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 20,
+  height: 692,
+  overflow: 'clip',
+});
+
+export const emptyState = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: 200,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+});

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { getMockScheduleDetailData } from '@/routes/teams/$teamId/schedules/-mock-data';
 
-import ScheduleDetailPanel from './ScheduleDetailPanel';
+import { ScheduleDetailPanel } from './ScheduleDetailPanel';
 
 const mockDataWithSchedules = getMockScheduleDetailData('2025-02-11');
 

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { getMockScheduleDetailData } from '@/routes/teams/$teamId/schedules/-mock-data';
+
+import ScheduleDetailPanel from './ScheduleDetailPanel';
+
+const mockDataWithSchedules = getMockScheduleDetailData('2025-02-11');
+
+const meta = {
+  title: 'Routes/Teams/Schedules/ScheduleDetailPanel',
+  component: ScheduleDetailPanel,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '선택된 날짜의 일정 세부 정보를 표시하는 패널 컴포넌트입니다. 일정 목록과 생성 버튼을 포함합니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    data: { control: 'object' },
+    onCreateSchedule: { action: 'create schedule clicked' },
+    onEditSchedule: { action: 'edit schedule clicked' },
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '400px', height: '600px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ScheduleDetailPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    data: mockDataWithSchedules,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '여러 개의 일정이 있는 날짜의 패널입니다.',
+      },
+    },
+  },
+};
+
+export const SingleSchedule: Story = {
+  args: {
+    data: {
+      selectedDate: '2025-02-10',
+      dayOfWeek: '월',
+      schedules: [
+        {
+          id: '1',
+          title: '지역 리그 1차전',
+          location: '잠실종합운동장',
+          startTime: '오후 02:00',
+          endTime: '오후 04:00',
+          category: '대회/리그',
+          date: '2025-02-10',
+        },
+      ],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '하나의 일정만 있는 날짜의 패널입니다.',
+      },
+    },
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    data: {
+      selectedDate: '2025-02-12',
+      dayOfWeek: '수',
+      schedules: [],
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '일정이 없는 날짜의 패널입니다. 빈 상태 메시지가 표시됩니다.',
+      },
+    },
+  },
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
@@ -5,7 +5,7 @@ import type { ScheduleDetailData } from '@/routes/teams/$teamId/schedules/-temp-
 
 import { ScheduleCreateForm } from './ScheduleCreateForm';
 import * as styles from './ScheduleDetailPanel.css';
-import ScheduleItem from './ScheduleItem';
+import { ScheduleItem } from './ScheduleItem';
 
 interface ScheduleDetailPanelProps {
   data: ScheduleDetailData;

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { PlusIcon } from '@/assets/icons';
 import type { ScheduleDetailData } from '@/routes/teams/$teamId/schedules/-temp-server-types';
 
 import * as styles from './ScheduleDetailPanel.css';
@@ -42,22 +43,7 @@ function ScheduleDetailPanel({
             <div className={styles.dayOfWeek}>{data.dayOfWeek}</div>
           </div>
           <button className={styles.createButton} onClick={handleCreateClick}>
-            <div className={styles.createIcon}>
-              <svg width='12' height='12' viewBox='0 0 14 14' fill='none'>
-                <path
-                  d='M1 7H13'
-                  stroke='currentColor'
-                  strokeWidth='1.5'
-                  strokeLinecap='round'
-                />
-                <path
-                  d='M7 1L7 13'
-                  stroke='currentColor'
-                  strokeWidth='1.5'
-                  strokeLinecap='round'
-                />
-              </svg>
-            </div>
+            <PlusIcon className={styles.createIcon} />
             일정 생성하기
           </button>
         </div>
@@ -70,7 +56,6 @@ function ScheduleDetailPanel({
             {data.schedules.length}개
           </span>
         </div>
-
         <div className={styles.scheduleListContainer}>
           {data.schedules.length > 0 ? (
             data.schedules.map(schedule => (

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react';
+
 import { PlusIcon } from '@/assets/icons';
 import type { ScheduleDetailData } from '@/routes/teams/$teamId/schedules/-temp-server-types';
 
+import { ScheduleCreateForm } from './ScheduleCreateForm';
 import * as styles from './ScheduleDetailPanel.css';
 import ScheduleItem from './ScheduleItem';
 
@@ -10,11 +13,21 @@ interface ScheduleDetailPanelProps {
   onEditSchedule?: (scheduleId: string) => void;
 }
 
+interface ScheduleFormData {
+  title: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  description: string;
+}
+
 export const ScheduleDetailPanel = ({
   data,
   onCreateSchedule,
   onEditSchedule,
 }: ScheduleDetailPanelProps) => {
+  const [isCreateMode, setIsCreateMode] = useState(false);
+
   const formatDisplayDate = (dateString: string) => {
     const date = new Date(dateString);
     const month = date.getMonth() + 1;
@@ -26,10 +39,33 @@ export const ScheduleDetailPanel = ({
   const { month, day } = formatDisplayDate(data.selectedDate);
 
   const handleCreateClick = () => {
+    setIsCreateMode(true);
     if (onCreateSchedule) {
       onCreateSchedule();
     }
   };
+
+  const handleCancelCreate = () => {
+    setIsCreateMode(false);
+  };
+
+  const handleSubmitCreate = (formData: ScheduleFormData) => {
+    console.log('일정 생성:', formData);
+    setIsCreateMode(false);
+    // TODO: 실제 일정 생성 API 호출
+  };
+
+  if (isCreateMode) {
+    return (
+      <div className={styles.rootContainer}>
+        <ScheduleCreateForm
+          selectedDate={data.selectedDate}
+          onCancel={handleCancelCreate}
+          onSubmit={handleSubmitCreate}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className={styles.rootContainer}>

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
@@ -1,0 +1,92 @@
+import type { ScheduleDetailData } from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+import * as styles from './ScheduleDetailPanel.css';
+import ScheduleItem from './ScheduleItem';
+
+interface ScheduleDetailPanelProps {
+  data: ScheduleDetailData;
+  onCreateSchedule?: () => void;
+  onEditSchedule?: (scheduleId: string) => void;
+}
+
+function ScheduleDetailPanel({
+  data,
+  onCreateSchedule,
+  onEditSchedule,
+}: ScheduleDetailPanelProps) {
+  const formatDisplayDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    return { month: `${month}월`, day: `${day}일` };
+  };
+
+  const { month, day } = formatDisplayDate(data.selectedDate);
+
+  const handleCreateClick = () => {
+    if (onCreateSchedule) {
+      onCreateSchedule();
+    }
+  };
+
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.headerContainer}>
+        <div className={styles.headerContent}>
+          <div className={styles.dateSection}>
+            <div className={styles.dateText}>
+              <span className={styles.monthText}>{month}</span>
+              <span className={styles.dayText}>{day}</span>
+            </div>
+            <div className={styles.dayOfWeek}>{data.dayOfWeek}</div>
+          </div>
+          <button className={styles.createButton} onClick={handleCreateClick}>
+            <div className={styles.createIcon}>
+              <svg width='12' height='12' viewBox='0 0 14 14' fill='none'>
+                <path
+                  d='M1 7H13'
+                  stroke='currentColor'
+                  strokeWidth='1.5'
+                  strokeLinecap='round'
+                />
+                <path
+                  d='M7 1L7 13'
+                  stroke='currentColor'
+                  strokeWidth='1.5'
+                  strokeLinecap='round'
+                />
+              </svg>
+            </div>
+            일정 생성하기
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.contentContainer}>
+        <div className={styles.scheduleHeader}>
+          <span className={styles.scheduleLabel}>등록된 일정</span>
+          <span className={styles.scheduleCount}>
+            {data.schedules.length}개
+          </span>
+        </div>
+
+        <div className={styles.scheduleListContainer}>
+          {data.schedules.length > 0 ? (
+            data.schedules.map(schedule => (
+              <ScheduleItem
+                key={schedule.id}
+                schedule={schedule}
+                onEdit={onEditSchedule}
+              />
+            ))
+          ) : (
+            <div className={styles.emptyState}>등록된 일정이 없습니다.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ScheduleDetailPanel;

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
@@ -10,11 +10,11 @@ interface ScheduleDetailPanelProps {
   onEditSchedule?: (scheduleId: string) => void;
 }
 
-function ScheduleDetailPanel({
+export const ScheduleDetailPanel = ({
   data,
   onCreateSchedule,
   onEditSchedule,
-}: ScheduleDetailPanelProps) {
+}: ScheduleDetailPanelProps) => {
   const formatDisplayDate = (dateString: string) => {
     const date = new Date(dateString);
     const month = date.getMonth() + 1;
@@ -72,6 +72,4 @@ function ScheduleDetailPanel({
       </div>
     </div>
   );
-}
-
-export default ScheduleDetailPanel;
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleDetailPanel.tsx
@@ -3,7 +3,10 @@ import { useState } from 'react';
 import { PlusIcon } from '@/assets/icons';
 import type { ScheduleDetailData } from '@/routes/teams/$teamId/schedules/-temp-server-types';
 
-import { ScheduleCreateForm } from './ScheduleCreateForm';
+import {
+  ScheduleCreateForm,
+  type ScheduleFormData,
+} from './ScheduleCreateForm';
 import * as styles from './ScheduleDetailPanel.css';
 import { ScheduleItem } from './ScheduleItem';
 
@@ -11,14 +14,6 @@ interface ScheduleDetailPanelProps {
   data: ScheduleDetailData;
   onCreateSchedule?: () => void;
   onEditSchedule?: (scheduleId: string) => void;
-}
-
-interface ScheduleFormData {
-  title: string;
-  date: string;
-  startTime: string;
-  endTime: string;
-  description: string;
 }
 
 export const ScheduleDetailPanel = ({

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleItem.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleItem.css.ts
@@ -9,8 +9,6 @@ export const rootContainer = style({
   borderRadius: 10,
   backgroundColor: lightThemeVars.color.primary[300],
   padding: '12px 20px 24px',
-  width: '100%',
-  maxWidth: 330,
 });
 
 export const headerContainer = style({

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleItem.css.ts
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleItem.css.ts
@@ -1,0 +1,84 @@
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const rootContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  borderRadius: 10,
+  backgroundColor: lightThemeVars.color.primary[300],
+  padding: '12px 20px 24px',
+  width: '100%',
+  maxWidth: 330,
+});
+
+export const headerContainer = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
+export const editButton = style({
+  border: 'none',
+  cursor: 'pointer',
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+  ':hover': {
+    color: lightThemeVars.color.gray[600],
+  },
+});
+
+export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+});
+
+export const title = style({
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  wordBreak: 'break-word',
+  color: lightThemeVars.color.black,
+  fontSize: 16,
+  fontWeight: 600,
+});
+
+export const infoContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.gray[500],
+  fontSize: 14,
+  fontWeight: 500,
+});
+
+export const location = style({
+  color: lightThemeVars.color.gray[500],
+});
+
+export const timeContainer = style({
+  display: 'flex',
+  gap: 8,
+});
+
+export const timeText = style({
+  color: lightThemeVars.color.gray[500],
+});
+
+export const categoryTag = style({
+  alignSelf: 'flex-start', // NOTE: flex 안에서 alignItems: stretch 가 기본값이어서, 본인 크기만큼만 갖도록 명시적으로 설정
+  marginTop: 12,
+  borderRadius: 90,
+  backgroundColor: lightThemeVars.color.white.main,
+  padding: '6px 10px',
+  lineHeight: 1.4,
+  letterSpacing: -0.35,
+  color: lightThemeVars.color.primary[700],
+  fontSize: 14,
+  fontWeight: 500,
+});

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleItem.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleItem.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ScheduleItem from './ScheduleItem';
+
+const meta = {
+  title: 'Routes/Teams/Schedules/ScheduleItem',
+  component: ScheduleItem,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '개별 일정을 표시하는 컴포넌트입니다. 일정의 제목, 위치, 시간, 카테고리를 보여줍니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    schedule: { control: 'object' },
+    onEdit: { action: 'edit clicked' },
+  },
+  decorators: [
+    Story => (
+      <div style={{ width: '330px', padding: '20px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ScheduleItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const League: Story = {
+  args: {
+    schedule: {
+      id: '1',
+      title:
+        '2025 제1차 경기도 꿈나무 축구대회 2025 제1차 경기도 꿈나무 축구대회',
+      location: '서울 성동구 왕십리로 22',
+      startTime: '오전 09:00',
+      endTime: '오전 11:00',
+      category: '대회/리그',
+      date: '2025-02-11',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '대회/리그 카테고리의 일정입니다.',
+      },
+    },
+  },
+};
+
+export const Friendly: Story = {
+  args: {
+    schedule: {
+      id: '2',
+      title: '강남FC vs 서초FC 친선경기',
+      location: '강남구민체육센터',
+      startTime: '오후 01:00',
+      endTime: '오후 03:00',
+      category: '친선 매치',
+      date: '2025-02-11',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '친선 매치 카테고리의 일정입니다.',
+      },
+    },
+  },
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleItem.stories.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleItem.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import ScheduleItem from './ScheduleItem';
+import { ScheduleItem } from './ScheduleItem';
 
 const meta = {
   title: 'Routes/Teams/Schedules/ScheduleItem',

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleItem.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleItem.tsx
@@ -7,7 +7,7 @@ interface ScheduleItemProps {
   onEdit?: (scheduleId: string) => void;
 }
 
-function ScheduleItem({ schedule, onEdit }: ScheduleItemProps) {
+export const ScheduleItem = ({ schedule, onEdit }: ScheduleItemProps) => {
   const handleEditClick = () => {
     if (onEdit) {
       onEdit(schedule.id);
@@ -35,6 +35,4 @@ function ScheduleItem({ schedule, onEdit }: ScheduleItemProps) {
       <div className={styles.categoryTag}>{schedule.category}</div>
     </div>
   );
-}
-
-export default ScheduleItem;
+};

--- a/src/routes/teams/$teamId/schedules/-components/ScheduleItem.tsx
+++ b/src/routes/teams/$teamId/schedules/-components/ScheduleItem.tsx
@@ -1,0 +1,40 @@
+import type { Schedule } from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+import * as styles from './ScheduleItem.css';
+
+interface ScheduleItemProps {
+  schedule: Schedule;
+  onEdit?: (scheduleId: string) => void;
+}
+
+function ScheduleItem({ schedule, onEdit }: ScheduleItemProps) {
+  const handleEditClick = () => {
+    if (onEdit) {
+      onEdit(schedule.id);
+    }
+  };
+
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.headerContainer}>
+        <button className={styles.editButton} onClick={handleEditClick}>
+          수정하기
+        </button>
+      </div>
+      <div className={styles.contentContainer}>
+        <div className={styles.title}>{schedule.title}</div>
+        <div className={styles.infoContainer}>
+          <div className={styles.location}>{schedule.location}</div>
+          <div className={styles.timeContainer}>
+            <div className={styles.timeText}>{schedule.startTime}</div>
+            <div className={styles.timeText}>~</div>
+            <div className={styles.timeText}>{schedule.endTime}</div>
+          </div>
+        </div>
+      </div>
+      <div className={styles.categoryTag}>{schedule.category}</div>
+    </div>
+  );
+}
+
+export default ScheduleItem;

--- a/src/routes/teams/$teamId/schedules/-components/index.ts
+++ b/src/routes/teams/$teamId/schedules/-components/index.ts
@@ -3,3 +3,4 @@ export * from './CalendarHeader';
 export * from './CalendarGrid';
 export * from './ScheduleDetailPanel';
 export * from './ScheduleItem';
+export * from './ScheduleCreateForm';

--- a/src/routes/teams/$teamId/schedules/-components/index.ts
+++ b/src/routes/teams/$teamId/schedules/-components/index.ts
@@ -1,0 +1,5 @@
+export * from './ScheduleCalendar';
+export * from './CalendarHeader';
+export * from './CalendarGrid';
+export * from './ScheduleDetailPanel';
+export * from './ScheduleItem';

--- a/src/routes/teams/$teamId/schedules/-mock-data.ts
+++ b/src/routes/teams/$teamId/schedules/-mock-data.ts
@@ -1,0 +1,219 @@
+import type {
+  CalendarData,
+  CalendarDay,
+  Schedule,
+  ScheduleDetailData,
+  ScheduleFilter,
+} from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+const schedule1: Schedule[] = [
+  {
+    id: '1',
+    title: '지역 리그 1차전',
+    location: '잠실종합운동장',
+    startTime: '오후 02:00',
+    endTime: '오후 04:00',
+    category: '대회/리그',
+    date: '2025-02-10',
+  },
+];
+
+const schedules10: Schedule[] = [
+  {
+    id: '2',
+    title: '선수단 조회',
+    location: '훈련장',
+    startTime: '오전 06:00',
+    endTime: '오전 06:30',
+    category: '기타',
+    date: '2025-02-11',
+  },
+  {
+    id: '3',
+    title: '체력 단련 훈련',
+    location: '훈련장',
+    startTime: '오전 07:00',
+    endTime: '오전 08:30',
+    category: '기타',
+    date: '2025-02-11',
+  },
+  {
+    id: '4',
+    title: '2025 제1차 경기도 꿈나무 축구대회',
+    location: '서울 성동구 왕십리로 22',
+    startTime: '오전 09:00',
+    endTime: '오전 11:00',
+    category: '대회/리그',
+    date: '2025-02-11',
+  },
+  {
+    id: '5',
+    title: '유소년팀 친선경기',
+    location: '목동경기장',
+    startTime: '오전 10:00',
+    endTime: '오전 12:00',
+    category: '친선 매치',
+    date: '2025-02-11',
+  },
+  {
+    id: '6',
+    title: '점심 식사 및 휴식',
+    location: '클럽하우스',
+    startTime: '오후 12:00',
+    endTime: '오후 01:00',
+    category: '기타',
+    date: '2025-02-11',
+  },
+  {
+    id: '7',
+    title: '강남FC vs 서초FC 친선경기',
+    location: '강남구민체육센터',
+    startTime: '오후 01:00',
+    endTime: '오후 03:00',
+    category: '친선 매치',
+    date: '2025-02-11',
+  },
+  {
+    id: '8',
+    title: '경기 분석 회의',
+    location: '회의실',
+    startTime: '오후 03:30',
+    endTime: '오후 04:30',
+    category: '기타',
+    date: '2025-02-11',
+  },
+  {
+    id: '9',
+    title: '부상 선수 재활 훈련',
+    location: '재활센터',
+    startTime: '오후 04:00',
+    endTime: '오후 05:00',
+    category: '기타',
+    date: '2025-02-11',
+  },
+  {
+    id: '10',
+    title: '팀 미팅',
+    location: '클럽하우스',
+    startTime: '오후 05:00',
+    endTime: '오후 06:00',
+    category: '기타',
+    date: '2025-02-11',
+  },
+  {
+    id: '11',
+    title: '장비 점검 및 정리',
+    location: '장비실',
+    startTime: '오후 06:30',
+    endTime: '오후 07:00',
+    category: '기타',
+    date: '2025-02-11',
+  },
+];
+
+// 모의 일정 데이터 (합쳐진 배열)
+export const mockSchedules: Schedule[] = [...schedule1, ...schedules10];
+
+// 2025년 2월 캘린더 생성 함수
+function generateCalendarDays(selectedDate: string): CalendarDay[] {
+  const days: CalendarDay[] = [];
+  const currentDate = new Date();
+  const today = currentDate.getDate();
+  const currentMonth = currentDate.getMonth();
+  const currentYear = currentDate.getFullYear();
+
+  // 2025년 2월 기준
+  const year = 2025;
+  const month = 1; // 0-based (February)
+
+  // 1월의 마지막 날들 (26, 27, 28, 29, 30, 31)
+  const januaryDays = Array.from({ length: 6 }, (_, index) => ({
+    date: 26 + index,
+    isCurrentMonth: false,
+    isToday: false,
+    isSelected: false,
+    schedules: [],
+  }));
+  days.push(...januaryDays);
+
+  // 2월의 날들 (1-28)
+  const februaryDays = Array.from({ length: 28 }, (_, index) => {
+    const date = index + 1;
+    const dateStr = `2025-02-${date.toString().padStart(2, '0')}`;
+    const daySchedules = mockSchedules.filter(
+      schedule => schedule.date === dateStr,
+    );
+
+    return {
+      date,
+      isCurrentMonth: true,
+      isToday: year === currentYear && month === currentMonth && date === today,
+      isSelected: dateStr === selectedDate,
+      schedules: daySchedules,
+    };
+  });
+  days.push(...februaryDays);
+
+  // 3월의 첫 날들 (1-8)
+  const marchDays = Array.from({ length: 8 }, (_, index) => ({
+    date: index + 1,
+    isCurrentMonth: false,
+    isToday: false,
+    isSelected: false,
+    schedules: [],
+  }));
+  days.push(...marchDays);
+
+  return days;
+}
+
+// 필터 데이터 생성
+function generateFilters(): ScheduleFilter[] {
+  const filters: ScheduleFilter[] = [
+    { category: '대회/리그', count: 0, isActive: true },
+    { category: '친선 매치', count: 0, isActive: true },
+    { category: '기타', count: 0, isActive: true },
+  ];
+
+  // 각 카테고리별 일정 개수 계산
+  mockSchedules.forEach(schedule => {
+    const filter = filters.find(f => f.category === schedule.category);
+    if (filter) {
+      filter.count += 1;
+    }
+  });
+
+  return filters;
+}
+
+// 캘린더 데이터 생성
+export function getMockCalendarData(selectedDate: string): CalendarData {
+  return {
+    year: 2025,
+    month: 2, // February
+    days: generateCalendarDays(selectedDate),
+    filters: generateFilters(),
+  };
+}
+
+// 선택된 날짜의 세부 데이터 생성
+export function getMockScheduleDetailData(
+  selectedDate: string,
+): ScheduleDetailData {
+  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+  const date = new Date(selectedDate);
+  const dayOfWeek = dayNames[date.getDay()];
+
+  const schedules = mockSchedules.filter(
+    schedule => schedule.date === selectedDate,
+  );
+
+  return {
+    selectedDate,
+    dayOfWeek,
+    schedules,
+  };
+}
+
+// 초기 선택 날짜
+export const DEFAULT_SELECTED_DATE = '2025-02-11';

--- a/src/routes/teams/$teamId/schedules/-route.css.ts
+++ b/src/routes/teams/$teamId/schedules/-route.css.ts
@@ -1,0 +1,41 @@
+import { commonPageRoot } from '@/styles/page.css';
+import { lightThemeVars } from '@/styles/theme.css';
+
+import { style } from '@vanilla-extract/css';
+
+export const rootContainer = style([
+  commonPageRoot,
+  {
+    display: 'flex',
+    backgroundColor: lightThemeVars.color.white.background,
+    paddingTop: 60,
+    paddingBottom: 60,
+    overflow: 'hidden',
+  },
+]);
+
+export const pageHeader = style({
+  borderBottom: `1px solid ${lightThemeVars.color.primary[100]}`,
+  backgroundColor: lightThemeVars.color.white.main,
+  padding: '20px 32px',
+  lineHeight: 1.4,
+  letterSpacing: -0.4,
+  color: lightThemeVars.color.primary[700],
+  fontSize: 16,
+  fontWeight: 500,
+});
+
+export const contentGrid = style({
+  display: 'flex',
+  gap: 20,
+});
+
+export const calendarColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const detailColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+});

--- a/src/routes/teams/$teamId/schedules/-temp-server-types.ts
+++ b/src/routes/teams/$teamId/schedules/-temp-server-types.ts
@@ -1,0 +1,40 @@
+// 일정관리 페이지에서 사용되는 임시 서버 타입 정의
+
+export type ScheduleCategory = '대회/리그' | '친선 매치' | '기타';
+
+export interface Schedule {
+  id: string;
+  title: string;
+  location: string;
+  startTime: string; // 시간 문자열 (예: "오전 09:00")
+  endTime: string; // 시간 문자열 (예: "오후 06:00")
+  category: ScheduleCategory;
+  date: string; // YYYY-MM-DD 형식
+}
+
+export interface CalendarDay {
+  date: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  schedules: Schedule[];
+}
+
+export interface ScheduleFilter {
+  category: ScheduleCategory;
+  count: number;
+  isActive: boolean;
+}
+
+export interface CalendarData {
+  year: number;
+  month: number;
+  days: CalendarDay[];
+  filters: ScheduleFilter[];
+}
+
+export interface ScheduleDetailData {
+  selectedDate: string; // YYYY-MM-DD 형식
+  dayOfWeek: string; // 요일 (예: "화")
+  schedules: Schedule[];
+}

--- a/src/routes/teams/$teamId/schedules/route.tsx
+++ b/src/routes/teams/$teamId/schedules/route.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useState } from 'react';
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { usePageTitle } from '@/hooks';
+import type {
+  CalendarData,
+  ScheduleDetailData,
+} from '@/routes/teams/$teamId/schedules/-temp-server-types';
+
+import { ScheduleCalendar, ScheduleDetailPanel } from './-components';
+import {
+  DEFAULT_SELECTED_DATE,
+  getMockCalendarData,
+  getMockScheduleDetailData,
+} from './-mock-data';
+import * as styles from './-route.css';
+
+export const Route = createFileRoute('/teams/$teamId/schedules')({
+  component: SchedulesPage,
+});
+
+function SchedulesPage() {
+  usePageTitle('일정 관리');
+
+  const [selectedDate, setSelectedDate] = useState(DEFAULT_SELECTED_DATE);
+  const [calendarData, setCalendarData] = useState<CalendarData>(() =>
+    getMockCalendarData(selectedDate),
+  );
+  const [detailData, setDetailData] = useState<ScheduleDetailData>(() =>
+    getMockScheduleDetailData(selectedDate),
+  );
+
+  const handleDateSelect = (date: string) => {
+    setSelectedDate(date);
+    setDetailData(getMockScheduleDetailData(date));
+    setCalendarData(getMockCalendarData(date));
+  };
+
+  const handleMonthChange = (year: number, month: number) => {
+    // 새로운 월의 첫 번째 날로 선택 날짜 변경
+    const newSelectedDate = `${year}-${month.toString().padStart(2, '0')}-01`;
+    setSelectedDate(newSelectedDate);
+    setCalendarData(getMockCalendarData(newSelectedDate));
+    setDetailData(getMockScheduleDetailData(newSelectedDate));
+  };
+
+  const handleFilterToggle = (category: string) => {
+    setCalendarData(prevData => ({
+      ...prevData,
+      filters: prevData.filters.map(filter =>
+        filter.category === category
+          ? { ...filter, isActive: !filter.isActive }
+          : filter,
+      ),
+    }));
+  };
+
+  const handleCreateSchedule = useCallback(() => {
+    console.log('일정 생성:', selectedDate);
+  }, [selectedDate]);
+
+  const handleEditSchedule = useCallback((scheduleId: string) => {
+    console.log('일정 수정:', scheduleId);
+  }, []);
+
+  return (
+    <div className={styles.rootContainer}>
+      <div className={styles.contentGrid}>
+        <div className={styles.calendarColumn}>
+          <ScheduleCalendar
+            data={calendarData}
+            onDateSelect={handleDateSelect}
+            onMonthChange={handleMonthChange}
+            onFilterToggle={handleFilterToggle}
+          />
+        </div>
+        <div className={styles.detailColumn}>
+          <ScheduleDetailPanel
+            data={detailData}
+            onCreateSchedule={handleCreateSchedule}
+            onEditSchedule={handleEditSchedule}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/routes/teams/create/-components/TeamCreateForm.tsx
+++ b/src/routes/teams/create/-components/TeamCreateForm.tsx
@@ -46,7 +46,10 @@ interface TeamCreateFormProps {
   onSuccess: () => void;
 }
 
-export function TeamCreateForm({ onSubmit, onSuccess }: TeamCreateFormProps) {
+export const TeamCreateForm = ({
+  onSubmit,
+  onSuccess,
+}: TeamCreateFormProps) => {
   const [profileImagePreview, setProfileImagePreview] = useState<string | null>(
     null,
   );
@@ -376,4 +379,4 @@ export function TeamCreateForm({ onSubmit, onSuccess }: TeamCreateFormProps) {
       </form>
     </div>
   );
-}
+};

--- a/src/routes/teams/create/-components/UniformColorPicker.tsx
+++ b/src/routes/teams/create/-components/UniformColorPicker.tsx
@@ -17,10 +17,10 @@ const colorTypes = [
   { key: 'socks', label: '스타킹' },
 ] as const;
 
-export function UniformColorPicker({
+export const UniformColorPicker = ({
   uniformColors,
   onColorChange,
-}: UniformColorPickerProps) {
+}: UniformColorPickerProps) => {
   return (
     <div className={styles.uniformColors}>
       {colorTypes.map(({ key, label }) => (
@@ -53,4 +53,4 @@ export function UniformColorPicker({
       ))}
     </div>
   );
-}
+};


### PR DESCRIPTION
## Description

- [Jira Ticket: MAT-365](https://match-day.atlassian.net/browse/MAT-365) 팀 일정 관리 페이지 - 캘린더 퍼블리싱
- [Jira Ticket: MAT-366](https://match-day.atlassian.net/browse/MAT-366) 팀 일정 관리 페이지 - 일일 일정 리스트 퍼블리싱
- [Jira Ticket: MAT-367](https://match-day.atlassian.net/browse/MAT-367) 팀 일정 관리 페이지 - 일정 등록 영역 퍼블리싱

## Changes

- [x] 팀 일정 관리 페이지 퍼블리싱

기타

- [x] 커서 규칙에 스타일링 개선점들 추가
- [x] 컨벤션에 맞지 않는 기존 `default export` 제거

### Screenshots

(스크린샷 첨부)

## Todo

- [ ] API, 디자인 확정 사항 반영
